### PR TITLE
[#70] Implement memory core, Interface to make things cloneable and handy toString impls

### DIFF
--- a/backend/mars-interpreter/src/main/kotlin/internal/ICloneable.kt
+++ b/backend/mars-interpreter/src/main/kotlin/internal/ICloneable.kt
@@ -1,0 +1,7 @@
+package software.shonk.interpreter.internal
+
+/** Interface for cloneable objects. */
+internal interface ICloneable<T> {
+    /** Clones the object, creating a deep copy. */
+    fun deepCopy(): T
+}

--- a/backend/mars-interpreter/src/main/kotlin/internal/addressing/AddressMode.kt
+++ b/backend/mars-interpreter/src/main/kotlin/internal/addressing/AddressMode.kt
@@ -16,5 +16,18 @@ internal enum class AddressMode {
     // <
     B_PRE_DECREMENT,
     // >
-    B_POST_INCREMENT,
+    B_POST_INCREMENT;
+
+    override fun toString(): String {
+        return when (this) {
+            IMMEDIATE -> "# (Immediate)"
+            DIRECT -> "$ (Direct)"
+            A_INDIRECT -> "* (A Indirect)"
+            B_INDIRECT -> "@ (B Indirect)"
+            A_PRE_DECREMENT -> "{ (A Pre Decrement)"
+            A_POST_INCREMENT -> "} (A Post Increment)"
+            B_PRE_DECREMENT -> "< (B Pre Decrement)"
+            B_POST_INCREMENT -> "> (B Post Increment)"
+        }
+    }
 }

--- a/backend/mars-interpreter/src/main/kotlin/internal/addressing/Modifier.kt
+++ b/backend/mars-interpreter/src/main/kotlin/internal/addressing/Modifier.kt
@@ -7,5 +7,17 @@ internal enum class Modifier {
     BA,
     F,
     X,
-    I,
+    I;
+
+    override fun toString(): String {
+        return when (this) {
+            A -> "A"
+            B -> "B"
+            AB -> "AB"
+            BA -> "BA"
+            F -> "F"
+            X -> "X"
+            I -> "I"
+        }
+    }
 }

--- a/backend/mars-interpreter/src/main/kotlin/internal/instruction/AbstractInstruction.kt
+++ b/backend/mars-interpreter/src/main/kotlin/internal/instruction/AbstractInstruction.kt
@@ -1,5 +1,6 @@
 package software.shonk.interpreter.internal.instruction
 
+import software.shonk.interpreter.internal.ICloneable
 import software.shonk.interpreter.internal.addressing.AddressMode
 import software.shonk.interpreter.internal.addressing.Modifier
 import software.shonk.interpreter.internal.process.AbstractProcess
@@ -11,7 +12,7 @@ internal abstract class AbstractInstruction(
     var addressModeA: AddressMode,
     var addressModeB: AddressMode,
     var modifier: Modifier,
-) {
+) : ICloneable<AbstractInstruction> {
 
     abstract fun execute(process: AbstractProcess)
 

--- a/backend/mars-interpreter/src/main/kotlin/internal/memory/MemoryCore.kt
+++ b/backend/mars-interpreter/src/main/kotlin/internal/memory/MemoryCore.kt
@@ -1,0 +1,16 @@
+package software.shonk.interpreter.internal.memory
+
+import software.shonk.interpreter.internal.instruction.AbstractInstruction
+
+internal class MemoryCore(memorySize: Int, defaultInstruction: AbstractInstruction) : ICore {
+    private val memory: Array<AbstractInstruction> =
+        Array(memorySize) { defaultInstruction.deepCopy() }
+
+    override fun loadAbsolute(address: Int): AbstractInstruction {
+        return memory[address % memory.size]
+    }
+
+    override fun storeAbsolute(address: Int, instruction: AbstractInstruction) {
+        memory[address % memory.size] = instruction
+    }
+}

--- a/backend/mars-interpreter/src/test/kotlin/memory/TestMemoryCore.kt
+++ b/backend/mars-interpreter/src/test/kotlin/memory/TestMemoryCore.kt
@@ -1,0 +1,65 @@
+package memory
+
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import mocks.MockInstruction
+import org.junit.jupiter.api.Test
+import software.shonk.interpreter.internal.addressing.AddressMode
+import software.shonk.interpreter.internal.addressing.Modifier
+import software.shonk.interpreter.internal.memory.MemoryCore
+
+class TestMemoryCore {
+    @Test
+    fun testInitializesCorrectly() {
+        val defaultInstruction =
+            MockInstruction(42, 69, AddressMode.DIRECT, AddressMode.DIRECT, Modifier.I)
+        val memoryCore = MemoryCore(8000, defaultInstruction = defaultInstruction)
+
+        for (i in 0 until 8000) {
+            val instruction = memoryCore.loadAbsolute(i)
+            assert(instruction !== defaultInstruction)
+        }
+    }
+
+    @Test
+    fun testReadWriteInBounds() {
+        val defaultInstruction =
+            MockInstruction(42, 69, AddressMode.DIRECT, AddressMode.DIRECT, Modifier.I)
+        val memoryCore = MemoryCore(8000, defaultInstruction = defaultInstruction)
+
+        val instruction = MockInstruction(1, 2, AddressMode.DIRECT, AddressMode.DIRECT, Modifier.I)
+        memoryCore.storeAbsolute(42, instruction)
+        val out = memoryCore.loadAbsolute(42)
+
+        assertNotEquals(defaultInstruction, out)
+        assertEquals(instruction, out)
+    }
+
+    @Test
+    fun testReadWriteOutOfBoundsPositive() {
+        val defaultInstruction =
+            MockInstruction(42, 69, AddressMode.DIRECT, AddressMode.DIRECT, Modifier.I)
+        val memoryCore = MemoryCore(10, defaultInstruction = defaultInstruction)
+
+        val instruction = MockInstruction(1, 2, AddressMode.DIRECT, AddressMode.DIRECT, Modifier.I)
+        memoryCore.storeAbsolute(20, instruction)
+        val out = memoryCore.loadAbsolute(20)
+
+        assertNotEquals(defaultInstruction, out)
+        assertEquals(instruction, out)
+    }
+
+    @Test
+    fun testReadWriteOutOfBoundsNegative() {
+        val defaultInstruction =
+            MockInstruction(42, 69, AddressMode.DIRECT, AddressMode.DIRECT, Modifier.I)
+        val memoryCore = MemoryCore(10, defaultInstruction = defaultInstruction)
+
+        val instruction = MockInstruction(1, 2, AddressMode.DIRECT, AddressMode.DIRECT, Modifier.I)
+        memoryCore.storeAbsolute(-20, instruction)
+        val out = memoryCore.loadAbsolute(20)
+
+        assertNotEquals(defaultInstruction, out)
+        assertEquals(instruction, out)
+    }
+}

--- a/backend/mars-interpreter/src/test/kotlin/mocks/MockInstruction.kt
+++ b/backend/mars-interpreter/src/test/kotlin/mocks/MockInstruction.kt
@@ -1,0 +1,26 @@
+package mocks
+
+import software.shonk.interpreter.internal.addressing.AddressMode
+import software.shonk.interpreter.internal.addressing.Modifier
+import software.shonk.interpreter.internal.instruction.AbstractInstruction
+import software.shonk.interpreter.internal.process.AbstractProcess
+
+internal class MockInstruction(
+    aField: Int,
+    bField: Int,
+    addressModeA: AddressMode,
+    addressModeB: AddressMode,
+    modifier: Modifier,
+) : AbstractInstruction(aField, bField, addressModeA, addressModeB, modifier) {
+    override fun execute(process: AbstractProcess) {
+        // Nothing here :3
+    }
+
+    override fun deepCopy(): AbstractInstruction {
+        return MockInstruction(aField, bField, addressModeA, addressModeB, modifier)
+    }
+
+    override fun toString(): String {
+        return "MockInstruction(aField=$aField, bField=$bField, addressModeA=$addressModeA, addressModeB=$addressModeB, modifier=$modifier)"
+    }
+}


### PR DESCRIPTION
This PR implements memory core and basic test utilities.
Also implemented are a few handy toString implementations and also an interface to facilitate creating a clone of instructions as to not reference the same object every time when initializing.

Review from @nikkischnelle is optional, @PietHelzel approval is required.