### PR TITLE
111 add v1 api endpoint to create a new lobby

### DIFF
--- a/backend/api/src/main/kotlin/software/shonk/adapters/incoming/ShorkInterpreterController.kt
+++ b/backend/api/src/main/kotlin/software/shonk/adapters/incoming/ShorkInterpreterController.kt
@@ -79,12 +79,7 @@ fun Route.configureShorkInterpreterControllerV1() {
 
     post("/lobby") {
         val lobbyId = shorkUseCase.createLobby()
-        val result = shorkUseCase.getLobbyStatus(lobbyId)
-
-        result.onFailure {
-            call.respond(HttpStatusCode.InternalServerError, it.message ?: UNKNOWN_ERROR_MESSAGE)
-        }
-        result.onSuccess { call.respond(HttpStatusCode.Created, lobbyId.toString()) }
+        call.respond(HttpStatusCode.Created, lobbyId.toString())
         return@post
     }
 }

--- a/backend/api/src/main/kotlin/software/shonk/adapters/incoming/ShorkInterpreterController.kt
+++ b/backend/api/src/main/kotlin/software/shonk/adapters/incoming/ShorkInterpreterController.kt
@@ -76,6 +76,17 @@ fun Route.configureShorkInterpreterControllerV1() {
         lobbyStatus.onSuccess { call.respond(HttpStatusCode.OK, it) }
         return@get
     }
+
+    post("/lobby") {
+        val lobbyId = shorkUseCase.createLobby()
+        val result = shorkUseCase.getLobbyStatus(lobbyId)
+
+        result.onFailure {
+            call.respond(HttpStatusCode.InternalServerError, it.message ?: UNKNOWN_ERROR_MESSAGE)
+        }
+        result.onSuccess { call.respond(HttpStatusCode.Created, lobbyId.toString()) }
+        return@post
+    }
 }
 
 @Serializable data class Program(val code: String)

--- a/backend/api/src/test/kotlin/software/shonk/adapters/incoming/ShorkInterpreterControllerV1IT.kt
+++ b/backend/api/src/test/kotlin/software/shonk/adapters/incoming/ShorkInterpreterControllerV1IT.kt
@@ -111,4 +111,17 @@ class ShorkInterpreterControllerV1IT() : AbstractControllerTest() {
         assertEquals(HttpStatusCode.Created, result.status)
         assertEquals("1", result.bodyAsText())
     }
+
+    @Test
+    fun `test create a multiple new lobbies`() = runTest {
+        val result = client.post("/api/v1/lobby")
+        val result2 = client.post("/api/v1/lobby")
+        val result3 = client.post("/api/v1/lobby")
+        assertEquals(HttpStatusCode.Created, result.status)
+        assertEquals("1", result.bodyAsText())
+        assertEquals(HttpStatusCode.Created, result2.status)
+        assertEquals("2", result2.bodyAsText())
+        assertEquals(HttpStatusCode.Created, result3.status)
+        assertEquals("3", result3.bodyAsText())
+    }
 }

--- a/backend/api/src/test/kotlin/software/shonk/adapters/incoming/ShorkInterpreterControllerV1IT.kt
+++ b/backend/api/src/test/kotlin/software/shonk/adapters/incoming/ShorkInterpreterControllerV1IT.kt
@@ -104,4 +104,11 @@ class ShorkInterpreterControllerV1IT() : AbstractControllerTest() {
         assertEquals("FINISHED", responseData["gameState"])
         assertEquals("B", responseData["result.winner"])
     }
+
+    @Test
+    fun `test create a new lobby`() = runTest {
+        val result = client.post("/api/v1/lobby")
+        assertEquals(HttpStatusCode.Created, result.status)
+        assertEquals("1", result.bodyAsText())
+    }
 }


### PR DESCRIPTION
I only wrote one test for this endpoint because it just creates an empty lobby and tests regarding submitting new code etc. to a lobby is already handled in the ShorkServiceTest. Also the ShorkServiceTest already tests for creating a new lobby. But please give me a short feedback, if further testing is required for this endpoint