### PR TITLE
#184 Add Kotlin Logging Provider

### DIFF
--- a/backend/api/build.gradle.kts
+++ b/backend/api/build.gradle.kts
@@ -4,6 +4,7 @@ val kotlinVersion: String by project
 val ktorVersion: String by project
 val koinVersion: String by project
 val mockkVersion: String by project
+val logbackVersion: String by project
 
 plugins {
     application
@@ -55,6 +56,7 @@ dependencies {
     implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
     implementation("io.ktor:ktor-server-core:$ktorVersion")
     implementation("io.ktor:ktor-server-netty:$ktorVersion")
+    implementation("ch.qos.logback:logback-classic:$logbackVersion")
     testImplementation("io.ktor:ktor-server-test-host-jvm:$ktorVersion")
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("io.mockk:mockk:${mockkVersion}")

--- a/backend/api/gradle.properties
+++ b/backend/api/gradle.properties
@@ -3,3 +3,4 @@ ktorVersion=2.3.12
 kotlinVersion=2.0.20
 koinVersion=4.0.0
 mockkVersion=1.13.13
+logbackVersion=1.5.12

--- a/backend/api/src/main/kotlin/software/shonk/adapters/incoming/ShorkInterpreterController.kt
+++ b/backend/api/src/main/kotlin/software/shonk/adapters/incoming/ShorkInterpreterController.kt
@@ -9,17 +9,21 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import kotlinx.serialization.Serializable
 import org.koin.ktor.ext.inject
+import org.slf4j.LoggerFactory
 import software.shonk.application.port.incoming.ShorkUseCase
 
 const val UNKNOWN_ERROR_MESSAGE = "Unknown Error"
 const val defaultLobby = 0L
 
 fun Route.configureShorkInterpreterControllerV0() {
+    val logger = LoggerFactory.getLogger("ShorkInterpreterControllerV0")
+
     val shorkUseCase by inject<ShorkUseCase>()
 
     get("/status") {
         val useCaseResponse = shorkUseCase.getLobbyStatus(defaultLobby)
         useCaseResponse.onFailure {
+            logger.error("Failed to get lobby status", it)
             call.respond(HttpStatusCode.BadRequest, it.message ?: UNKNOWN_ERROR_MESSAGE)
         }
         useCaseResponse.onSuccess { call.respond(it) }
@@ -31,6 +35,7 @@ fun Route.configureShorkInterpreterControllerV0() {
 
         val result = shorkUseCase.addProgramToLobby(defaultLobby, player, program)
         result.onFailure {
+            logger.error("Failed to add program to lobby", it)
             call.respond(HttpStatusCode.BadRequest, it.message ?: UNKNOWN_ERROR_MESSAGE)
         }
         result.onSuccess { call.respond(HttpStatusCode.OK) }
@@ -39,6 +44,7 @@ fun Route.configureShorkInterpreterControllerV0() {
 }
 
 fun Route.configureShorkInterpreterControllerV1() {
+    val logger = LoggerFactory.getLogger("ShorkInterpreterControllerV1")
     val shorkUseCase by inject<ShorkUseCase>()
 
     get("/lobby/{lobbyId}/code/{player}") {
@@ -49,6 +55,7 @@ fun Route.configureShorkInterpreterControllerV1() {
         val program = shorkUseCase.getProgramFromLobby(lobbyId, player)
 
         program.onFailure {
+            logger.error("Failed to get program from lobby", it)
             call.respond(HttpStatusCode.BadRequest, it.message ?: UNKNOWN_ERROR_MESSAGE)
         }
 

--- a/backend/shork/build.gradle.kts
+++ b/backend/shork/build.gradle.kts
@@ -13,6 +13,8 @@ repositories {
 }
 
 dependencies {
+    implementation("ch.qos.logback:logback-classic:1.5.12")
+
     testImplementation(kotlin("test"))
     // https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-params
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.11.3")


### PR DESCRIPTION
Add Logback as L4J Logging provider and add examples for implementation in Shork and Endpoints.

If the rest of the logging implementation should also be completed here, just say so and I will also implement logging everywhere else. It'd probably be best, though, if everyone implements logging for their own code.