### PR TITLE
112 add v1 api endpoint to query lobby status

### DIFF
--- a/backend/api/src/test/kotlin/software/shonk/adapters/incoming/ShorkInterpreterControllerV1IT.kt
+++ b/backend/api/src/test/kotlin/software/shonk/adapters/incoming/ShorkInterpreterControllerV1IT.kt
@@ -74,7 +74,8 @@ class ShorkInterpreterControllerV1IT() : AbstractControllerTest() {
             "result": {
                 "winner": "UNDECIDED"
             }
-        }"""
+        }
+        """
                 .trimIndent()
         assertEquals(expectedStatus, result.bodyAsText())
     }

--- a/backend/api/src/test/kotlin/software/shonk/adapters/incoming/ShorkInterpreterControllerV1IT.kt
+++ b/backend/api/src/test/kotlin/software/shonk/adapters/incoming/ShorkInterpreterControllerV1IT.kt
@@ -5,6 +5,7 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.server.config.*
 import io.ktor.server.testing.*
+import io.netty.handler.codec.http2.HttpConversionUtil.parseStatus
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -23,6 +24,18 @@ class ShorkInterpreterControllerV1IT() : AbstractControllerTest() {
             moduleApiV0() // @TODO: delete once v0 functionality is implemented in v1
             moduleApiV1()
         }
+    }
+
+    private suspend fun parseStatus(response: HttpResponse): Map<String, String> {
+        val responseJson = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+        val result = responseJson["result"]?.jsonObject
+        val resultWinner = result?.get("winner")?.jsonPrimitive?.content ?: "UNDECIDED"
+        return mapOf(
+            "playerASubmitted" to responseJson["playerASubmitted"]!!.jsonPrimitive.content,
+            "playerBSubmitted" to responseJson["playerBSubmitted"]!!.jsonPrimitive.content,
+            "gameState" to responseJson["gameState"]!!.jsonPrimitive.content,
+            "result.winner" to resultWinner,
+        )
     }
 
     @Test
@@ -56,5 +69,22 @@ class ShorkInterpreterControllerV1IT() : AbstractControllerTest() {
         val result = client.get("/api/v1/lobby/0/code/playerA")
         assertEquals(HttpStatusCode.BadRequest, result.status)
         assert(result.bodyAsText().contains("No player with that name in the lobby"))
+    }
+
+    @Test
+    fun `test get lobby status with invalid ID`() = runTest {
+        val result = client.get("/api/v1/lobby/status/1")
+        assertEquals(HttpStatusCode.BadRequest, result.status)
+        assert(result.bodyAsText().contains("No lobby with that id"))
+    }
+
+    @Test
+    fun `test get lobby status with valid (default) ID`() = runTest {
+        val result = client.get("/api/v1/lobby/status/0")
+        val responseData = parseStatus(result)
+        assertEquals("false", responseData["playerASubmitted"])
+        assertEquals("false", responseData["playerBSubmitted"])
+        assertEquals("NOT_STARTED", responseData["gameState"])
+        assertEquals("UNDECIDED", responseData["result.winner"])
     }
 }


### PR DESCRIPTION
the user can now request a lobby status with his lobby ID. I created two tests, one negative and the other positive (using the default lobby paramater) to make sure it works property