### PR TITLE
#76 Implement SHORK Settings

### DIFF
--- a/backend/shork/src/main/kotlin/Settings.kt
+++ b/backend/shork/src/main/kotlin/Settings.kt
@@ -26,8 +26,6 @@ class Settings(
      * execution of a single instruction of every players' program.
      */
     val maximumTicks: Int = 80000,
-    /** The minimum separation between two processes. */
-    val mininumSeparation: Int = 100,
 
     /** The maximum number of processes that can be running at the same time. */
     val maximumProcessesPerPlayer: Int = 64,
@@ -36,6 +34,16 @@ class Settings(
     val readDistance: Int = coreSize,
     /** The maximum distance a write operation can access. */
     val writeDistance: Int = coreSize,
+
+    /** The minimum separation between two processes. */
+    val minimumSeparation: Int = 100,
+    /** The number of instructions between two processes when created */
+    val separation: Int = 100,
+    /**
+     * Whether the separation between two processes is random. `separation` is ignored if this is
+     * true
+     */
+    val randomSeparation: Boolean = false,
 ) {
     internal fun toInternalSettings() =
         software.shonk.interpreter.internal.settings.InternalSettings(
@@ -49,9 +57,11 @@ class Settings(
                 Modifier.I,
             ), // TODO: replace with actual instruction once the parser exists
             maximumTicks,
-            mininumSeparation,
             maximumProcessesPerPlayer,
             readDistance,
             writeDistance,
+            minimumSeparation,
+            separation,
+            randomSeparation,
         )
 }

--- a/backend/shork/src/main/kotlin/Settings.kt
+++ b/backend/shork/src/main/kotlin/Settings.kt
@@ -31,6 +31,11 @@ class Settings(
 
     /** The maximum number of processes that can be running at the same time. */
     val maximumProcessesPerPlayer: Int = 64,
+
+    /** The maximum distance a read operation can access. */
+    val readDistance: Int = coreSize,
+    /** The maximum distance a write operation can access. */
+    val writeDistance: Int = coreSize,
 ) {
     internal fun toInternalSettings() =
         software.shonk.interpreter.internal.settings.InternalSettings(
@@ -46,5 +51,7 @@ class Settings(
             maximumTicks,
             mininumSeparation,
             maximumProcessesPerPlayer,
+            readDistance,
+            writeDistance,
         )
 }

--- a/backend/shork/src/main/kotlin/Settings.kt
+++ b/backend/shork/src/main/kotlin/Settings.kt
@@ -28,6 +28,9 @@ class Settings(
     val maximumTicks: Int = 80000,
     /** The minimum separation between two processes. */
     val mininumSeparation: Int = 100,
+
+    /** The maximum number of processes that can be running at the same time. */
+    val maximumProcessesPerPlayer: Int = 64,
 ) {
     internal fun toInternalSettings() =
         software.shonk.interpreter.internal.settings.InternalSettings(
@@ -42,5 +45,6 @@ class Settings(
             ), // TODO: replace with actual instruction once the parser exists
             maximumTicks,
             mininumSeparation,
+            maximumProcessesPerPlayer,
         )
 }

--- a/backend/shork/src/main/kotlin/Shork.kt
+++ b/backend/shork/src/main/kotlin/Shork.kt
@@ -15,7 +15,8 @@ class Shork : IShork {
         val internalSettings = settings.toInternalSettings()
         val shork = InternalShork(internalSettings)
 
-        var lastLocation = 0
+        var address = -1 * settings.separation
+
         for ((player, sourceCode) in programs.entries) {
             logger.info("Player $player:")
             val tokenizer = Tokenizer(sourceCode)
@@ -44,14 +45,20 @@ class Shork : IShork {
             val program = Program(player, shork)
             shork.addProgram(program)
 
-            val start = lastLocation
+            address =
+                if (internalSettings.randomSeparation) {
+                    (0 until internalSettings.coreSize).random()
+                    // @TODO: Test once functionality is inside InternalShork
+                } else {
+                    address + internalSettings.separation
+                }
+
+            val start = address
             logger.info("Storing the program of player $player at location $start")
             for (instruction in instructions) {
-                shork.memoryCore.storeAbsolute(lastLocation++, instruction)
+                shork.memoryCore.storeAbsolute(address++, instruction)
             }
-
             program.createProcessAt(start)
-            lastLocation += internalSettings.minimumSeparation + 100
         }
 
         val outcome =

--- a/backend/shork/src/main/kotlin/internal/AbstractInternalShork.kt
+++ b/backend/shork/src/main/kotlin/internal/AbstractInternalShork.kt
@@ -13,7 +13,7 @@ internal abstract class AbstractInternalShork(
     val settings: InternalSettings,
     val gameDataCollector: IGameDataCollector = settings.gameDataCollector,
 ) {
-    val memoryCore = MemoryCore(settings.coreSize, settings.initialInstruction, gameDataCollector)
+    val memoryCore = MemoryCore(settings.coreSize, settings)
 
     abstract fun addProgram(vararg program: AbstractProgram)
 

--- a/backend/shork/src/main/kotlin/internal/instruction/AbstractArithmeticInstruction.kt
+++ b/backend/shork/src/main/kotlin/internal/instruction/AbstractArithmeticInstruction.kt
@@ -32,10 +32,15 @@ internal abstract class AbstractArithmeticInstruction(
 
     override fun execute(process: AbstractProcess) {
         val core = process.program.shork.memoryCore
-        val sourceAddress = resolve(process, aField, addressModeA)
-        val destinationAddress = resolve(process, bField, addressModeB)
+        val sourceAddress = core.resolveForReading(process.programCounter, aField, addressModeA)
+        val destinationAddress =
+            core.resolveForReading(process.programCounter, bField, addressModeB)
+        val destinationWriteAddress =
+            core.resolveForWriting(process.programCounter, bField, addressModeB)
+
         val sourceInstruction = core.loadAbsolute(sourceAddress)
         val destinationInstruction = core.loadAbsolute(destinationAddress)
+        val destinationWriteInstruction = core.loadAbsolute(destinationWriteAddress)
 
         errorOccured = false
 
@@ -49,7 +54,7 @@ internal abstract class AbstractArithmeticInstruction(
                         )
                     })
 
-                result?.let({ destinationInstruction.aField = result })
+                result?.let({ destinationWriteInstruction.aField = result })
             }
             Modifier.B -> {
                 val result =
@@ -60,7 +65,7 @@ internal abstract class AbstractArithmeticInstruction(
                         )
                     })
 
-                result?.let({ destinationInstruction.bField = result })
+                result?.let({ destinationWriteInstruction.bField = result })
             }
             Modifier.AB -> {
                 val result =
@@ -71,7 +76,7 @@ internal abstract class AbstractArithmeticInstruction(
                         )
                     })
 
-                result?.let({ destinationInstruction.bField = result })
+                result?.let({ destinationWriteInstruction.bField = result })
             }
             Modifier.BA -> {
                 val result =
@@ -82,7 +87,7 @@ internal abstract class AbstractArithmeticInstruction(
                         )
                     })
 
-                result?.let({ destinationInstruction.aField = result })
+                result?.let({ destinationWriteInstruction.aField = result })
             }
             Modifier.F,
             Modifier.I -> {
@@ -94,7 +99,7 @@ internal abstract class AbstractArithmeticInstruction(
                         )
                     })
 
-                resultA?.let({ destinationInstruction.aField = resultA })
+                resultA?.let({ destinationWriteInstruction.aField = resultA })
 
                 val resultB =
                     executeWithHandling({
@@ -104,7 +109,7 @@ internal abstract class AbstractArithmeticInstruction(
                         )
                     })
 
-                resultB?.let({ destinationInstruction.bField = resultB })
+                resultB?.let({ destinationWriteInstruction.bField = resultB })
             }
             Modifier.X -> {
                 val result1 =
@@ -115,7 +120,7 @@ internal abstract class AbstractArithmeticInstruction(
                         )
                     })
 
-                result1?.let({ destinationInstruction.bField = result1 })
+                result1?.let({ destinationWriteInstruction.bField = result1 })
 
                 val result2 =
                     executeWithHandling({
@@ -125,7 +130,7 @@ internal abstract class AbstractArithmeticInstruction(
                         )
                     })
 
-                result2?.let({ destinationInstruction.aField = result2 })
+                result2?.let({ destinationWriteInstruction.aField = result2 })
             }
         }
 

--- a/backend/shork/src/main/kotlin/internal/instruction/AbstractInstruction.kt
+++ b/backend/shork/src/main/kotlin/internal/instruction/AbstractInstruction.kt
@@ -16,53 +16,6 @@ internal abstract class AbstractInstruction(
 
     abstract fun execute(process: AbstractProcess)
 
-    /**
-     * Resolve the absolute address of a field based on the address mode and the content of the
-     * field. In case the AddressMode is one of the Pre/Post In/Decrement modes, the resolve
-     * function **will** modify the destination field.
-     *
-     * @param process The process that is executing the instruction
-     * @param field The field to resolve the address of, either the A or B field
-     * @param mode The address mode to use, must be the address mode of the field (A or B)
-     * @return The resolved absolute address
-     */
-    fun resolve(process: AbstractProcess, field: Int, mode: AddressMode): Int {
-        val referenceAddress = process.programCounter + field // Address we are pointing to
-        val instruction = process.program.shork.memoryCore.loadAbsolute(referenceAddress)
-        return when (mode) {
-            AddressMode.IMMEDIATE -> {
-                process.programCounter
-            }
-            AddressMode.DIRECT -> {
-                referenceAddress
-            }
-            AddressMode.A_INDIRECT -> {
-                referenceAddress + instruction.aField
-            }
-            AddressMode.B_INDIRECT -> {
-                referenceAddress + instruction.bField
-            }
-            AddressMode.A_PRE_DECREMENT -> {
-                instruction.aField -= 1
-                referenceAddress + instruction.aField
-            }
-            AddressMode.B_PRE_DECREMENT -> {
-                instruction.bField -= 1
-                referenceAddress + instruction.bField
-            }
-            AddressMode.A_POST_INCREMENT -> {
-                val address = referenceAddress + instruction.aField
-                instruction.aField += 1
-                address
-            }
-            AddressMode.B_POST_INCREMENT -> {
-                val address = referenceAddress + instruction.bField
-                instruction.bField += 1
-                address
-            }
-        }
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/backend/shork/src/main/kotlin/internal/instruction/Djn.kt
+++ b/backend/shork/src/main/kotlin/internal/instruction/Djn.kt
@@ -13,9 +13,10 @@ internal class Djn(
 ) : AbstractInstruction(aField, bField, addressModeA, addressModeB, modifier) {
     override fun execute(process: AbstractProcess) {
         val core = process.program.shork.memoryCore
-        val checkZeroAddress = resolve(process, bField, addressModeB)
+        val checkZeroAddress = core.resolveForReading(process.programCounter, bField, addressModeB)
         val checkZeroInstruction = core.loadAbsolute(checkZeroAddress)
-        val absoluteJumpDestination = resolve(process, aField, addressModeA)
+        val absoluteJumpDestination =
+            core.resolveForReading(process.programCounter, aField, addressModeA)
 
         val shouldJump =
             when (modifier) {

--- a/backend/shork/src/main/kotlin/internal/instruction/Jmn.kt
+++ b/backend/shork/src/main/kotlin/internal/instruction/Jmn.kt
@@ -13,9 +13,10 @@ internal class Jmn(
 ) : AbstractInstruction(aField, bField, addressModeA, addressModeB, modifier) {
     override fun execute(process: AbstractProcess) {
         val core = process.program.shork.memoryCore
-        val checkZeroAddress = resolve(process, bField, addressModeB)
+        val checkZeroAddress = core.resolveForReading(process.programCounter, bField, addressModeB)
         val checkZeroInstruction = core.loadAbsolute(checkZeroAddress)
-        val absoluteJumpDestination = resolve(process, aField, addressModeA)
+        val absoluteJumpDestination =
+            core.resolveForReading(process.programCounter, aField, addressModeA)
 
         val shouldJump =
             when (modifier) {

--- a/backend/shork/src/main/kotlin/internal/instruction/Jmp.kt
+++ b/backend/shork/src/main/kotlin/internal/instruction/Jmp.kt
@@ -12,7 +12,12 @@ internal class Jmp(
     modifier: Modifier,
 ) : AbstractInstruction(aField, bField, addressModeA, addressModeB, modifier) {
     override fun execute(process: AbstractProcess) {
-        val absoluteJumpDestination = resolve(process, aField, addressModeA)
+        val absoluteJumpDestination =
+            process.program.shork.memoryCore.resolveForReading(
+                process.programCounter,
+                aField,
+                addressModeA,
+            )
         process.programCounter = absoluteJumpDestination
         process.dontIncrementProgramCounter = true
     }

--- a/backend/shork/src/main/kotlin/internal/instruction/Jmz.kt
+++ b/backend/shork/src/main/kotlin/internal/instruction/Jmz.kt
@@ -14,9 +14,10 @@ internal class Jmz(
 
     override fun execute(process: AbstractProcess) {
         val core = process.program.shork.memoryCore
-        val checkZeroAddress = resolve(process, bField, addressModeB)
+        val checkZeroAddress = core.resolveForReading(process.programCounter, bField, addressModeB)
         val checkZeroInstruction = core.loadAbsolute(checkZeroAddress)
-        val absoluteJumpDestination = resolve(process, aField, addressModeA)
+        val absoluteJumpDestination =
+            core.resolveForReading(process.programCounter, aField, addressModeA)
 
         val shouldJump =
             when (modifier) {

--- a/backend/shork/src/main/kotlin/internal/instruction/Mov.kt
+++ b/backend/shork/src/main/kotlin/internal/instruction/Mov.kt
@@ -14,8 +14,10 @@ internal class Mov(
 
     override fun execute(process: AbstractProcess) {
         val core = process.program.shork.memoryCore
-        val sourceAddress = resolve(process, aField, addressModeA)
-        val destinationAddress = resolve(process, bField, addressModeB)
+
+        val sourceAddress = core.resolveForReading(process.programCounter, aField, addressModeA)
+        val destinationAddress =
+            core.resolveForWriting(process.programCounter, bField, addressModeB)
         val sourceInstruction = core.loadAbsolute(sourceAddress)
         val destinationInstruction = core.loadAbsolute(destinationAddress)
 
@@ -41,7 +43,8 @@ internal class Mov(
                 destinationInstruction.bField = sourceInstruction.aField
             }
             Modifier.I -> {
-                core.storeAbsolute(destinationAddress, sourceInstruction.deepCopy())
+                val address = core.resolveForWriting(process.programCounter, bField, addressModeB)
+                core.storeAbsolute(address, sourceInstruction.deepCopy())
             }
         }
     }

--- a/backend/shork/src/main/kotlin/internal/instruction/Seq.kt
+++ b/backend/shork/src/main/kotlin/internal/instruction/Seq.kt
@@ -13,8 +13,10 @@ internal class Seq(
 ) : AbstractInstruction(aField, bField, addressModeA, addressModeB, modifier) {
     override fun execute(process: AbstractProcess) {
         val core = process.program.shork.memoryCore
-        val sourceAddress = resolve(process, aField, addressModeA)
-        val destinationAddress = resolve(process, bField, addressModeB)
+
+        val sourceAddress = core.resolveForReading(process.programCounter, aField, addressModeA)
+        val destinationAddress =
+            core.resolveForReading(process.programCounter, bField, addressModeB)
         val sourceInstruction = core.loadAbsolute(sourceAddress)
         val destinationInstruction = core.loadAbsolute(destinationAddress)
 

--- a/backend/shork/src/main/kotlin/internal/instruction/Slt.kt
+++ b/backend/shork/src/main/kotlin/internal/instruction/Slt.kt
@@ -13,8 +13,9 @@ internal class Slt(
 ) : AbstractInstruction(aField, bField, addressModeA, addressModeB, modifier) {
     override fun execute(process: AbstractProcess) {
         val core = process.program.shork.memoryCore
-        val sourceAddress = resolve(process, aField, addressModeA)
-        val destinationAddress = resolve(process, bField, addressModeB)
+        val sourceAddress = core.resolveForReading(process.programCounter, aField, addressModeA)
+        val destinationAddress =
+            core.resolveForReading(process.programCounter, bField, addressModeB)
         val sourceInstruction = core.loadAbsolute(sourceAddress)
         val destinationInstruction = core.loadAbsolute(destinationAddress)
 

--- a/backend/shork/src/main/kotlin/internal/instruction/Sne.kt
+++ b/backend/shork/src/main/kotlin/internal/instruction/Sne.kt
@@ -13,8 +13,9 @@ internal class Sne(
 ) : AbstractInstruction(aField, bField, addressModeA, addressModeB, modifier) {
     override fun execute(process: AbstractProcess) {
         val core = process.program.shork.memoryCore
-        val sourceAddress = resolve(process, aField, addressModeA)
-        val destinationAddress = resolve(process, bField, addressModeB)
+        val sourceAddress = core.resolveForReading(process.programCounter, aField, addressModeA)
+        val destinationAddress =
+            core.resolveForReading(process.programCounter, bField, addressModeB)
         val sourceInstruction = core.loadAbsolute(sourceAddress)
         val destinationInstruction = core.loadAbsolute(destinationAddress)
 

--- a/backend/shork/src/main/kotlin/internal/instruction/Spl.kt
+++ b/backend/shork/src/main/kotlin/internal/instruction/Spl.kt
@@ -12,7 +12,8 @@ internal class Spl(
     modifier: Modifier,
 ) : AbstractInstruction(aField, bField, addressModeA, addressModeB, modifier) {
     override fun execute(process: AbstractProcess) {
-        val startAddress = resolve(process, aField, addressModeA)
+        val core = process.program.shork.memoryCore
+        val startAddress = core.resolveForReading(process.programCounter, aField, addressModeA)
         process.program.createProcessAt(startAddress)
     }
 

--- a/backend/shork/src/main/kotlin/internal/memory/ICore.kt
+++ b/backend/shork/src/main/kotlin/internal/memory/ICore.kt
@@ -1,5 +1,6 @@
 package software.shonk.interpreter.internal.memory
 
+import software.shonk.interpreter.internal.addressing.AddressMode
 import software.shonk.interpreter.internal.instruction.AbstractInstruction
 
 /** The interface for the memory core */
@@ -9,4 +10,10 @@ internal interface ICore {
 
     /** Writes an instruction to the given address */
     fun storeAbsolute(address: Int, instruction: AbstractInstruction)
+
+    /** Resolves the address of a field based on the address mode and the content of the field */
+    fun resolveForReading(sourceAddress: Int, field: Int, mode: AddressMode): Int
+
+    /** Resolves the address of a field based on the address mode and the content of the field */
+    fun resolveForWriting(sourceAddress: Int, field: Int, mode: AddressMode): Int
 }

--- a/backend/shork/src/main/kotlin/internal/memory/MemoryCore.kt
+++ b/backend/shork/src/main/kotlin/internal/memory/MemoryCore.kt
@@ -9,13 +9,13 @@ internal class MemoryCore(memorySize: Int, val settings: InternalSettings) : ICo
         Array(memorySize) { settings.initialInstruction.deepCopy() }
 
     override fun loadAbsolute(address: Int): AbstractInstruction {
-        val resolvedAddress = address % memory.size
+        val resolvedAddress = resolvedAddressBounds(address)
         settings.gameDataCollector.collectMemoryRead(resolvedAddress)
         return memory[resolvedAddress]
     }
 
     override fun storeAbsolute(address: Int, instruction: AbstractInstruction) {
-        val resolvedAddress = address % memory.size
+        val resolvedAddress = resolvedAddressBounds(address)
         settings.gameDataCollector.collectMemoryWrite(resolvedAddress, instruction)
         memory[resolvedAddress] = instruction
     }
@@ -28,6 +28,15 @@ internal class MemoryCore(memorySize: Int, val settings: InternalSettings) : ICo
     override fun resolveForWriting(sourceAddress: Int, field: Int, mode: AddressMode): Int {
         val maxDistance = settings.writeDistance
         return resolve(sourceAddress, field, mode, maxDistance)
+    }
+
+    private fun resolvedAddressBounds(address: Int): Int {
+        return if (address < 0) {
+            val negativeIndex = address % memory.size
+            (memory.size + negativeIndex) % memory.size
+        } else {
+            address % memory.size
+        }
     }
 
     /**

--- a/backend/shork/src/main/kotlin/internal/memory/MemoryCore.kt
+++ b/backend/shork/src/main/kotlin/internal/memory/MemoryCore.kt
@@ -1,5 +1,6 @@
 package software.shonk.interpreter.internal.memory
 
+import software.shonk.interpreter.internal.addressing.AddressMode
 import software.shonk.interpreter.internal.instruction.AbstractInstruction
 import software.shonk.interpreter.internal.settings.InternalSettings
 
@@ -17,5 +18,73 @@ internal class MemoryCore(memorySize: Int, val settings: InternalSettings) : ICo
         val resolvedAddress = address % memory.size
         settings.gameDataCollector.collectMemoryWrite(resolvedAddress, instruction)
         memory[resolvedAddress] = instruction
+    }
+
+    override fun resolveForReading(sourceAddress: Int, field: Int, mode: AddressMode): Int {
+        val maxDistance = settings.readDistance
+        return resolve(sourceAddress, field, mode, maxDistance)
+    }
+
+    override fun resolveForWriting(sourceAddress: Int, field: Int, mode: AddressMode): Int {
+        val maxDistance = settings.writeDistance
+        return resolve(sourceAddress, field, mode, maxDistance)
+    }
+
+    /**
+     * Resolve the absolute address of a field based on the address mode and the content of the
+     * field. In case the AddressMode is one of the Pre/Post In/Decrement modes, the resolve
+     * function **will** modify the destination field.
+     *
+     * @param sourceAddress The address of the instruction that is executing the operation
+     * @param field The field to resolve the address of, either the A or B field
+     * @param mode The address mode to use, must be the address mode of the field (A or B)
+     * @param maxAddressDistance The maximum distance the operation can access
+     * @return The resolved absolute address
+     */
+    private fun resolve(
+        sourceAddress: Int,
+        field: Int,
+        mode: AddressMode,
+        maxAddressDistance: Int,
+    ): Int {
+        val referenceAddress =
+            sourceAddress + (field % maxAddressDistance) // Address we are pointing to
+        val instruction = loadAbsolute(referenceAddress)
+
+        val addressOffset =
+            when (mode) {
+                AddressMode.IMMEDIATE -> {
+                    0
+                }
+                AddressMode.DIRECT -> {
+                    field
+                }
+                AddressMode.A_INDIRECT -> {
+                    field + instruction.aField
+                }
+                AddressMode.B_INDIRECT -> {
+                    field + instruction.bField
+                }
+                AddressMode.A_PRE_DECREMENT -> {
+                    instruction.aField -= 1
+                    field + instruction.aField
+                }
+                AddressMode.B_PRE_DECREMENT -> {
+                    instruction.bField -= 1
+                    field + instruction.bField
+                }
+                AddressMode.A_POST_INCREMENT -> {
+                    val offset = field + instruction.aField
+                    instruction.aField += 1
+                    offset
+                }
+                AddressMode.B_POST_INCREMENT -> {
+                    val offset = field + instruction.bField
+                    instruction.bField += 1
+                    offset
+                }
+            }
+
+        return sourceAddress + (addressOffset % maxAddressDistance)
     }
 }

--- a/backend/shork/src/main/kotlin/internal/memory/MemoryCore.kt
+++ b/backend/shork/src/main/kotlin/internal/memory/MemoryCore.kt
@@ -1,25 +1,21 @@
 package software.shonk.interpreter.internal.memory
 
 import software.shonk.interpreter.internal.instruction.AbstractInstruction
-import software.shonk.interpreter.internal.statistics.IGameDataCollector
+import software.shonk.interpreter.internal.settings.InternalSettings
 
-internal class MemoryCore(
-    memorySize: Int,
-    defaultInstruction: AbstractInstruction,
-    val gameDataCollector: IGameDataCollector,
-) : ICore {
+internal class MemoryCore(memorySize: Int, val settings: InternalSettings) : ICore {
     private val memory: Array<AbstractInstruction> =
-        Array(memorySize) { defaultInstruction.deepCopy() }
+        Array(memorySize) { settings.initialInstruction.deepCopy() }
 
     override fun loadAbsolute(address: Int): AbstractInstruction {
         val resolvedAddress = address % memory.size
-        gameDataCollector.collectMemoryRead(resolvedAddress)
+        settings.gameDataCollector.collectMemoryRead(resolvedAddress)
         return memory[resolvedAddress]
     }
 
     override fun storeAbsolute(address: Int, instruction: AbstractInstruction) {
         val resolvedAddress = address % memory.size
-        gameDataCollector.collectMemoryWrite(resolvedAddress, instruction)
+        settings.gameDataCollector.collectMemoryWrite(resolvedAddress, instruction)
         memory[resolvedAddress] = instruction
     }
 }

--- a/backend/shork/src/main/kotlin/internal/program/Program.kt
+++ b/backend/shork/src/main/kotlin/internal/program/Program.kt
@@ -21,6 +21,9 @@ internal class Program(id: String, shork: AbstractInternalShork) : AbstractProgr
     }
 
     override fun createProcessAt(startingAddress: Int) {
+        if (this.processes.size() >= this.shork.settings.maximumProcessesPerPlayer) {
+            return
+        }
         val newProcess = Process(this, startingAddress)
         this.processes.add(newProcess)
     }

--- a/backend/shork/src/main/kotlin/internal/settings/InternalSettings.kt
+++ b/backend/shork/src/main/kotlin/internal/settings/InternalSettings.kt
@@ -19,8 +19,6 @@ internal class InternalSettings(
      * execution of a single instruction of every players' program.
      */
     val maximumCycles: Int,
-    /** The minimum separation between two processes. */
-    val minimumSeparation: Int,
 
     /** The maximum number of processes that can be running at the same time. */
     val maximumProcessesPerPlayer: Int,
@@ -29,6 +27,16 @@ internal class InternalSettings(
     val readDistance: Int,
     /** The maximum distance a write operation can access. */
     val writeDistance: Int,
+
+    /** The minimum separation between two processes. */
+    val minimumSeparation: Int,
+    /** The number of instructions between two processes when created */
+    val separation: Int,
+    /**
+     * Whether the separation between two processes is random. `separation` is ignored if this is
+     * true
+     */
+    val randomSeparation: Boolean,
 
     /** The game data collector to use. */
     val gameDataCollector: IGameDataCollector = GameDataCollector(),

--- a/backend/shork/src/main/kotlin/internal/settings/InternalSettings.kt
+++ b/backend/shork/src/main/kotlin/internal/settings/InternalSettings.kt
@@ -21,6 +21,10 @@ internal class InternalSettings(
     val maximumCycles: Int,
     /** The minimum separation between two processes. */
     val minimumSeparation: Int,
+
+    /** The maximum number of processes that can be running at the same time. */
+    val maximumProcessesPerPlayer: Int,
+
     /** The game data collector to use. */
     val gameDataCollector: IGameDataCollector = GameDataCollector(),
 )

--- a/backend/shork/src/main/kotlin/internal/settings/InternalSettings.kt
+++ b/backend/shork/src/main/kotlin/internal/settings/InternalSettings.kt
@@ -25,6 +25,11 @@ internal class InternalSettings(
     /** The maximum number of processes that can be running at the same time. */
     val maximumProcessesPerPlayer: Int,
 
+    /** The maximum distance a read operation can access. */
+    val readDistance: Int,
+    /** The maximum distance a write operation can access. */
+    val writeDistance: Int,
+
     /** The game data collector to use. */
     val gameDataCollector: IGameDataCollector = GameDataCollector(),
 )

--- a/backend/shork/src/test/kotlin/TestInternalShork.kt
+++ b/backend/shork/src/test/kotlin/TestInternalShork.kt
@@ -12,11 +12,11 @@ import software.shonk.interpreter.internal.program.Program
 import software.shonk.interpreter.internal.settings.InternalSettings
 
 internal class TestInternalShork {
-    var settings = InternalSettings(8000, 100, KillProgramInstruction(), 1000, 100)
+    var settings = InternalSettings(8000, 100, KillProgramInstruction(), 1000, 100, 64)
 
     @BeforeEach
     fun setUp() {
-        settings = InternalSettings(8000, 100, KillProgramInstruction(), 1000, 100)
+        settings = InternalSettings(8000, 100, KillProgramInstruction(), 1000, 100, 64)
     }
 
     @Test

--- a/backend/shork/src/test/kotlin/TestInternalShork.kt
+++ b/backend/shork/src/test/kotlin/TestInternalShork.kt
@@ -9,14 +9,13 @@ import software.shonk.interpreter.internal.addressing.AddressMode
 import software.shonk.interpreter.internal.addressing.Modifier
 import software.shonk.interpreter.internal.instruction.Mov
 import software.shonk.interpreter.internal.program.Program
-import software.shonk.interpreter.internal.settings.InternalSettings
 
 internal class TestInternalShork {
-    var settings = InternalSettings(8000, 100, KillProgramInstruction(), 1000, 100, 64)
+    var settings = getDefaultInternalSettings(KillProgramInstruction())
 
     @BeforeEach
     fun setUp() {
-        settings = InternalSettings(8000, 100, KillProgramInstruction(), 1000, 100, 64)
+        settings = getDefaultInternalSettings(KillProgramInstruction())
     }
 
     @Test

--- a/backend/shork/src/test/kotlin/TestUtilities.kt
+++ b/backend/shork/src/test/kotlin/TestUtilities.kt
@@ -1,7 +1,11 @@
 import kotlin.test.junit5.JUnit5Asserter.fail
 import mocks.MockInstruction
 import org.junit.jupiter.api.Assertions.assertEquals
+import software.shonk.interpreter.internal.instruction.AbstractInstruction
 import software.shonk.interpreter.internal.memory.ICore
+import software.shonk.interpreter.internal.settings.InternalSettings
+import software.shonk.interpreter.internal.statistics.GameDataCollector
+import software.shonk.interpreter.internal.statistics.IGameDataCollector
 
 internal fun assertExecutionCountAtAddress(
     memoryCore: ICore,
@@ -16,4 +20,24 @@ internal fun assertExecutionCountAtAddress(
             "Expected instruction at address $address to be a MockInstruction, but was $instruction"
         )
     }
+}
+
+internal fun getDefaultInternalSettings(
+    initialInstruction: AbstractInstruction,
+    coreSize: Int = 8000,
+    instructionLimit: Int = 1000,
+    maximumCycles: Int = 1000,
+    minimumSeparation: Int = 100,
+    maximumProcessesPerPlayer: Int = 64,
+    gameDataCollector: IGameDataCollector = GameDataCollector(),
+): InternalSettings {
+    return InternalSettings(
+        coreSize,
+        instructionLimit,
+        initialInstruction,
+        maximumCycles,
+        minimumSeparation,
+        maximumProcessesPerPlayer,
+        gameDataCollector,
+    )
 }

--- a/backend/shork/src/test/kotlin/TestUtilities.kt
+++ b/backend/shork/src/test/kotlin/TestUtilities.kt
@@ -31,6 +31,8 @@ internal fun getDefaultInternalSettings(
     maximumProcessesPerPlayer: Int = 64,
     readDistance: Int = coreSize,
     writeDistance: Int = coreSize,
+    separation: Int = 100,
+    randomSeparation: Boolean = false,
     gameDataCollector: IGameDataCollector = GameDataCollector(),
 ): InternalSettings {
     return InternalSettings(
@@ -38,10 +40,12 @@ internal fun getDefaultInternalSettings(
         instructionLimit,
         initialInstruction,
         maximumCycles,
-        minimumSeparation,
         maximumProcessesPerPlayer,
         readDistance,
         writeDistance,
+        minimumSeparation,
+        separation,
+        randomSeparation,
         gameDataCollector,
     )
 }

--- a/backend/shork/src/test/kotlin/TestUtilities.kt
+++ b/backend/shork/src/test/kotlin/TestUtilities.kt
@@ -29,6 +29,8 @@ internal fun getDefaultInternalSettings(
     maximumCycles: Int = 1000,
     minimumSeparation: Int = 100,
     maximumProcessesPerPlayer: Int = 64,
+    readDistance: Int = coreSize,
+    writeDistance: Int = coreSize,
     gameDataCollector: IGameDataCollector = GameDataCollector(),
 ): InternalSettings {
     return InternalSettings(
@@ -38,6 +40,8 @@ internal fun getDefaultInternalSettings(
         maximumCycles,
         minimumSeparation,
         maximumProcessesPerPlayer,
+        readDistance,
+        writeDistance,
         gameDataCollector,
     )
 }

--- a/backend/shork/src/test/kotlin/instruction/TestAdd.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestAdd.kt
@@ -1,5 +1,6 @@
 package instruction
 
+import getDefaultInternalSettings
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -10,12 +11,11 @@ import software.shonk.interpreter.internal.instruction.Add
 import software.shonk.interpreter.internal.instruction.Dat
 import software.shonk.interpreter.internal.process.Process
 import software.shonk.interpreter.internal.program.Program
-import software.shonk.interpreter.internal.settings.InternalSettings
 
 internal class TestAdd {
 
     private val dat = Dat(5, 7, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
-    private val settings = InternalSettings(8000, 1000, dat, 1000, 100, 64)
+    private val settings = getDefaultInternalSettings(dat)
     private var shork = InternalShork(settings)
     private var program = Program("add", shork)
     private var process = Process(program, 0)

--- a/backend/shork/src/test/kotlin/instruction/TestAdd.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestAdd.kt
@@ -15,7 +15,7 @@ import software.shonk.interpreter.internal.settings.InternalSettings
 internal class TestAdd {
 
     private val dat = Dat(5, 7, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
-    private val settings = InternalSettings(8000, 1000, dat, 1000, 100)
+    private val settings = InternalSettings(8000, 1000, dat, 1000, 100, 64)
     private var shork = InternalShork(settings)
     private var program = Program("add", shork)
     private var process = Process(program, 0)

--- a/backend/shork/src/test/kotlin/instruction/TestDat.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestDat.kt
@@ -14,7 +14,7 @@ internal class TestDat {
     @Test
     fun testExecute() {
         val dat = Dat(0, 0, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
-        val settings = InternalSettings(8000, 1000, dat, 1000, 100)
+        val settings = InternalSettings(8000, 1000, dat, 1000, 100, 64)
         val shork = InternalShork(settings)
         val program = Program("A-", shork)
         val process = Process(program, 0)

--- a/backend/shork/src/test/kotlin/instruction/TestDat.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestDat.kt
@@ -1,5 +1,6 @@
 package instruction
 
+import getDefaultInternalSettings
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 import software.shonk.interpreter.internal.InternalShork
@@ -8,13 +9,12 @@ import software.shonk.interpreter.internal.addressing.Modifier
 import software.shonk.interpreter.internal.instruction.Dat
 import software.shonk.interpreter.internal.process.Process
 import software.shonk.interpreter.internal.program.Program
-import software.shonk.interpreter.internal.settings.InternalSettings
 
 internal class TestDat {
     @Test
     fun testExecute() {
         val dat = Dat(0, 0, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
-        val settings = InternalSettings(8000, 1000, dat, 1000, 100, 64)
+        val settings = getDefaultInternalSettings(dat)
         val shork = InternalShork(settings)
         val program = Program("A-", shork)
         val process = Process(program, 0)

--- a/backend/shork/src/test/kotlin/instruction/TestDiv.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestDiv.kt
@@ -17,7 +17,15 @@ internal class TestDiv {
 
     private val dat = Dat(5, 13, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
     private val settings =
-        InternalSettings(8000, 1000, dat, 1000, 100, gameDataCollector = MockGameDataCollector())
+        InternalSettings(
+            8000,
+            1000,
+            dat,
+            1000,
+            100,
+            64,
+            gameDataCollector = MockGameDataCollector(),
+        )
     private var shork = InternalShork(settings)
     private var program = Program("div", shork)
     private var process = Process(program, 0)

--- a/backend/shork/src/test/kotlin/instruction/TestDiv.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestDiv.kt
@@ -1,5 +1,6 @@
 package instruction
 
+import getDefaultInternalSettings
 import kotlin.test.assertEquals
 import mocks.MockGameDataCollector
 import org.junit.jupiter.api.BeforeEach
@@ -11,21 +12,12 @@ import software.shonk.interpreter.internal.instruction.Dat
 import software.shonk.interpreter.internal.instruction.Div
 import software.shonk.interpreter.internal.process.Process
 import software.shonk.interpreter.internal.program.Program
-import software.shonk.interpreter.internal.settings.InternalSettings
 
 internal class TestDiv {
 
     private val dat = Dat(5, 13, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
     private val settings =
-        InternalSettings(
-            8000,
-            1000,
-            dat,
-            1000,
-            100,
-            64,
-            gameDataCollector = MockGameDataCollector(),
-        )
+        getDefaultInternalSettings(dat, gameDataCollector = MockGameDataCollector())
     private var shork = InternalShork(settings)
     private var program = Program("div", shork)
     private var process = Process(program, 0)

--- a/backend/shork/src/test/kotlin/instruction/TestDjn.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestDjn.kt
@@ -16,7 +16,15 @@ internal class TestDjn {
 
     private val dat = Dat(0, 0, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
     private val settings =
-        InternalSettings(8000, 1000, dat, 1000, 100, gameDataCollector = MockGameDataCollector())
+        InternalSettings(
+            8000,
+            1000,
+            dat,
+            1000,
+            100,
+            64,
+            gameDataCollector = MockGameDataCollector(),
+        )
     private var shork = InternalShork(settings)
     private var program = Program("djn", shork)
 

--- a/backend/shork/src/test/kotlin/instruction/TestDjn.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestDjn.kt
@@ -1,5 +1,6 @@
 package instruction
 
+import getDefaultInternalSettings
 import kotlin.test.assertEquals
 import mocks.MockGameDataCollector
 import org.junit.jupiter.api.BeforeEach
@@ -10,21 +11,12 @@ import software.shonk.interpreter.internal.addressing.Modifier
 import software.shonk.interpreter.internal.instruction.Dat
 import software.shonk.interpreter.internal.instruction.Djn
 import software.shonk.interpreter.internal.program.Program
-import software.shonk.interpreter.internal.settings.InternalSettings
 
 internal class TestDjn {
 
     private val dat = Dat(0, 0, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
     private val settings =
-        InternalSettings(
-            8000,
-            1000,
-            dat,
-            1000,
-            100,
-            64,
-            gameDataCollector = MockGameDataCollector(),
-        )
+        getDefaultInternalSettings(dat, gameDataCollector = MockGameDataCollector())
     private var shork = InternalShork(settings)
     private var program = Program("djn", shork)
 

--- a/backend/shork/src/test/kotlin/instruction/TestJmn.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestJmn.kt
@@ -16,7 +16,15 @@ internal class TestJmn {
 
     private val dat = Dat(0, 0, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
     private val settings =
-        InternalSettings(8000, 1000, dat, 1000, 100, gameDataCollector = MockGameDataCollector())
+        InternalSettings(
+            8000,
+            1000,
+            dat,
+            1000,
+            100,
+            64,
+            gameDataCollector = MockGameDataCollector(),
+        )
     private var shork = InternalShork(settings)
     private var program = Program("jmn", shork)
 

--- a/backend/shork/src/test/kotlin/instruction/TestJmn.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestJmn.kt
@@ -1,5 +1,6 @@
 package instruction
 
+import getDefaultInternalSettings
 import kotlin.test.assertEquals
 import mocks.MockGameDataCollector
 import org.junit.jupiter.api.BeforeEach
@@ -10,21 +11,12 @@ import software.shonk.interpreter.internal.addressing.Modifier
 import software.shonk.interpreter.internal.instruction.Dat
 import software.shonk.interpreter.internal.instruction.Jmn
 import software.shonk.interpreter.internal.program.Program
-import software.shonk.interpreter.internal.settings.InternalSettings
 
 internal class TestJmn {
 
     private val dat = Dat(0, 0, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
     private val settings =
-        InternalSettings(
-            8000,
-            1000,
-            dat,
-            1000,
-            100,
-            64,
-            gameDataCollector = MockGameDataCollector(),
-        )
+        getDefaultInternalSettings(dat, gameDataCollector = MockGameDataCollector())
     private var shork = InternalShork(settings)
     private var program = Program("jmn", shork)
 

--- a/backend/shork/src/test/kotlin/instruction/TestJmp.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestJmp.kt
@@ -1,5 +1,6 @@
 package instruction
 
+import getDefaultInternalSettings
 import kotlin.test.assertEquals
 import mocks.MockGameDataCollector
 import org.junit.jupiter.api.BeforeEach
@@ -11,20 +12,11 @@ import software.shonk.interpreter.internal.instruction.Dat
 import software.shonk.interpreter.internal.instruction.Jmp
 import software.shonk.interpreter.internal.process.Process
 import software.shonk.interpreter.internal.program.Program
-import software.shonk.interpreter.internal.settings.InternalSettings
 
 internal class TestJmp {
     private val dat = Dat(0, 0, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
     private var settings =
-        InternalSettings(
-            8000,
-            1000,
-            dat,
-            1000,
-            100,
-            64,
-            gameDataCollector = MockGameDataCollector(),
-        )
+        getDefaultInternalSettings(dat, gameDataCollector = MockGameDataCollector())
     private var shork = InternalShork(settings)
 
     @BeforeEach

--- a/backend/shork/src/test/kotlin/instruction/TestJmp.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestJmp.kt
@@ -16,7 +16,15 @@ import software.shonk.interpreter.internal.settings.InternalSettings
 internal class TestJmp {
     private val dat = Dat(0, 0, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
     private var settings =
-        InternalSettings(8000, 1000, dat, 1000, 100, gameDataCollector = MockGameDataCollector())
+        InternalSettings(
+            8000,
+            1000,
+            dat,
+            1000,
+            100,
+            64,
+            gameDataCollector = MockGameDataCollector(),
+        )
     private var shork = InternalShork(settings)
 
     @BeforeEach

--- a/backend/shork/src/test/kotlin/instruction/TestJmz.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestJmz.kt
@@ -1,5 +1,6 @@
 package instruction
 
+import getDefaultInternalSettings
 import kotlin.test.assertEquals
 import mocks.MockGameDataCollector
 import org.junit.jupiter.api.BeforeEach
@@ -10,21 +11,12 @@ import software.shonk.interpreter.internal.addressing.Modifier
 import software.shonk.interpreter.internal.instruction.Dat
 import software.shonk.interpreter.internal.instruction.Jmz
 import software.shonk.interpreter.internal.program.Program
-import software.shonk.interpreter.internal.settings.InternalSettings
 
 internal class TestJmz {
 
     private val dat = Dat(0, 0, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
     private val settings =
-        InternalSettings(
-            8000,
-            1000,
-            dat,
-            1000,
-            100,
-            64,
-            gameDataCollector = MockGameDataCollector(),
-        )
+        getDefaultInternalSettings(dat, gameDataCollector = MockGameDataCollector())
     private var shork = InternalShork(settings)
     private var program = Program("jmz", shork)
 

--- a/backend/shork/src/test/kotlin/instruction/TestJmz.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestJmz.kt
@@ -16,7 +16,15 @@ internal class TestJmz {
 
     private val dat = Dat(0, 0, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
     private val settings =
-        InternalSettings(8000, 1000, dat, 1000, 100, gameDataCollector = MockGameDataCollector())
+        InternalSettings(
+            8000,
+            1000,
+            dat,
+            1000,
+            100,
+            64,
+            gameDataCollector = MockGameDataCollector(),
+        )
     private var shork = InternalShork(settings)
     private var program = Program("jmz", shork)
 

--- a/backend/shork/src/test/kotlin/instruction/TestMod.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestMod.kt
@@ -1,5 +1,6 @@
 package instruction
 
+import getDefaultInternalSettings
 import kotlin.test.assertEquals
 import mocks.MockGameDataCollector
 import org.junit.jupiter.api.BeforeEach
@@ -11,21 +12,12 @@ import software.shonk.interpreter.internal.instruction.Dat
 import software.shonk.interpreter.internal.instruction.Mod
 import software.shonk.interpreter.internal.process.Process
 import software.shonk.interpreter.internal.program.Program
-import software.shonk.interpreter.internal.settings.InternalSettings
 
 internal class TestMod {
 
     private val dat = Dat(5, 13, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
     private val settings =
-        InternalSettings(
-            8000,
-            1000,
-            dat,
-            1000,
-            100,
-            64,
-            gameDataCollector = MockGameDataCollector(),
-        )
+        getDefaultInternalSettings(dat, gameDataCollector = MockGameDataCollector())
     private var shork = InternalShork(settings)
     private var program = Program("mod", shork)
     private var process = Process(program, 0)

--- a/backend/shork/src/test/kotlin/instruction/TestMod.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestMod.kt
@@ -17,7 +17,15 @@ internal class TestMod {
 
     private val dat = Dat(5, 13, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
     private val settings =
-        InternalSettings(8000, 1000, dat, 1000, 100, gameDataCollector = MockGameDataCollector())
+        InternalSettings(
+            8000,
+            1000,
+            dat,
+            1000,
+            100,
+            64,
+            gameDataCollector = MockGameDataCollector(),
+        )
     private var shork = InternalShork(settings)
     private var program = Program("mod", shork)
     private var process = Process(program, 0)

--- a/backend/shork/src/test/kotlin/instruction/TestMov.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestMov.kt
@@ -15,7 +15,7 @@ import software.shonk.interpreter.internal.settings.InternalSettings
 internal class TestMov {
 
     private val dat = Dat(0, 0, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
-    private val settings = InternalSettings(8000, 1000, dat, 1000, 100)
+    private val settings = InternalSettings(8000, 1000, dat, 1000, 100, 64)
     private var shork = InternalShork(settings)
     private var program = Program("mov", shork)
     private var process = Process(program, 0)

--- a/backend/shork/src/test/kotlin/instruction/TestMov.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestMov.kt
@@ -1,5 +1,6 @@
 package instruction
 
+import getDefaultInternalSettings
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -10,12 +11,11 @@ import software.shonk.interpreter.internal.instruction.Dat
 import software.shonk.interpreter.internal.instruction.Mov
 import software.shonk.interpreter.internal.process.Process
 import software.shonk.interpreter.internal.program.Program
-import software.shonk.interpreter.internal.settings.InternalSettings
 
 internal class TestMov {
 
     private val dat = Dat(0, 0, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
-    private val settings = InternalSettings(8000, 1000, dat, 1000, 100, 64)
+    private val settings = getDefaultInternalSettings(dat)
     private var shork = InternalShork(settings)
     private var program = Program("mov", shork)
     private var process = Process(program, 0)

--- a/backend/shork/src/test/kotlin/instruction/TestMul.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestMul.kt
@@ -15,7 +15,7 @@ import software.shonk.interpreter.internal.settings.InternalSettings
 internal class TestMul {
 
     private val dat = Dat(5, 7, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
-    private val settings = InternalSettings(8000, 1000, dat, 1000, 100)
+    private val settings = InternalSettings(8000, 1000, dat, 1000, 100, 64)
     private var shork = InternalShork(settings)
     private var program = Program("mul", shork)
     private var process = Process(program, 0)

--- a/backend/shork/src/test/kotlin/instruction/TestMul.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestMul.kt
@@ -1,5 +1,6 @@
 package instruction
 
+import getDefaultInternalSettings
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -10,12 +11,11 @@ import software.shonk.interpreter.internal.instruction.Dat
 import software.shonk.interpreter.internal.instruction.Mul
 import software.shonk.interpreter.internal.process.Process
 import software.shonk.interpreter.internal.program.Program
-import software.shonk.interpreter.internal.settings.InternalSettings
 
 internal class TestMul {
 
     private val dat = Dat(5, 7, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
-    private val settings = InternalSettings(8000, 1000, dat, 1000, 100, 64)
+    private val settings = getDefaultInternalSettings(dat)
     private var shork = InternalShork(settings)
     private var program = Program("mul", shork)
     private var process = Process(program, 0)

--- a/backend/shork/src/test/kotlin/instruction/TestNop.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestNop.kt
@@ -15,7 +15,7 @@ import software.shonk.interpreter.internal.settings.InternalSettings
 internal class TestNop {
 
     private val dat = Dat(5, 13, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
-    private val settings = InternalSettings(8000, 1000, dat, 1000, 100)
+    private val settings = InternalSettings(8000, 1000, dat, 1000, 100, 64)
     private var shork = InternalShork(settings)
     private var program = Program("nop", shork)
     private var process = Process(program, 0)

--- a/backend/shork/src/test/kotlin/instruction/TestNop.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestNop.kt
@@ -1,5 +1,6 @@
 package instruction
 
+import getDefaultInternalSettings
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -10,12 +11,11 @@ import software.shonk.interpreter.internal.instruction.Dat
 import software.shonk.interpreter.internal.instruction.Nop
 import software.shonk.interpreter.internal.process.Process
 import software.shonk.interpreter.internal.program.Program
-import software.shonk.interpreter.internal.settings.InternalSettings
 
 internal class TestNop {
 
     private val dat = Dat(5, 13, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
-    private val settings = InternalSettings(8000, 1000, dat, 1000, 100, 64)
+    private val settings = getDefaultInternalSettings(dat)
     private var shork = InternalShork(settings)
     private var program = Program("nop", shork)
     private var process = Process(program, 0)

--- a/backend/shork/src/test/kotlin/instruction/TestSeq.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestSeq.kt
@@ -14,7 +14,7 @@ import software.shonk.interpreter.internal.settings.InternalSettings
 
 internal class TestSeq {
     private val dat = Dat(0, 0, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
-    private val settings = InternalSettings(8000, 1000, dat, 1000, 100)
+    private val settings = InternalSettings(8000, 1000, dat, 1000, 100, 64)
     private var shork = InternalShork(settings)
     private var program = Program("seq", shork)
     private var process = Process(program, 0)

--- a/backend/shork/src/test/kotlin/instruction/TestSeq.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestSeq.kt
@@ -1,5 +1,6 @@
 package instruction
 
+import getDefaultInternalSettings
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -10,11 +11,10 @@ import software.shonk.interpreter.internal.instruction.Dat
 import software.shonk.interpreter.internal.instruction.Seq
 import software.shonk.interpreter.internal.process.Process
 import software.shonk.interpreter.internal.program.Program
-import software.shonk.interpreter.internal.settings.InternalSettings
 
 internal class TestSeq {
     private val dat = Dat(0, 0, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
-    private val settings = InternalSettings(8000, 1000, dat, 1000, 100, 64)
+    private val settings = getDefaultInternalSettings(dat)
     private var shork = InternalShork(settings)
     private var program = Program("seq", shork)
     private var process = Process(program, 0)

--- a/backend/shork/src/test/kotlin/instruction/TestSlt.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestSlt.kt
@@ -15,7 +15,7 @@ import software.shonk.interpreter.internal.settings.InternalSettings
 
 internal class TestSlt {
     private val dat = Dat(0, 0, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
-    private val settings = InternalSettings(8000, 1000, dat, 1000, 100)
+    private val settings = InternalSettings(8000, 1000, dat, 1000, 100, 64)
     private var shork = InternalShork(settings)
     private var program = Program("slt", shork)
     private var process = Process(program, 0)

--- a/backend/shork/src/test/kotlin/instruction/TestSlt.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestSlt.kt
@@ -1,5 +1,6 @@
 package instruction
 
+import getDefaultInternalSettings
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -11,11 +12,10 @@ import software.shonk.interpreter.internal.instruction.Seq
 import software.shonk.interpreter.internal.instruction.Slt
 import software.shonk.interpreter.internal.process.Process
 import software.shonk.interpreter.internal.program.Program
-import software.shonk.interpreter.internal.settings.InternalSettings
 
 internal class TestSlt {
     private val dat = Dat(0, 0, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
-    private val settings = InternalSettings(8000, 1000, dat, 1000, 100, 64)
+    private val settings = getDefaultInternalSettings(dat)
     private var shork = InternalShork(settings)
     private var program = Program("slt", shork)
     private var process = Process(program, 0)

--- a/backend/shork/src/test/kotlin/instruction/TestSne.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestSne.kt
@@ -1,5 +1,6 @@
 package instruction
 
+import getDefaultInternalSettings
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -10,11 +11,10 @@ import software.shonk.interpreter.internal.instruction.Dat
 import software.shonk.interpreter.internal.instruction.Sne
 import software.shonk.interpreter.internal.process.Process
 import software.shonk.interpreter.internal.program.Program
-import software.shonk.interpreter.internal.settings.InternalSettings
 
 internal class TestSne {
     private val dat = Dat(0, 0, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
-    private val settings = InternalSettings(8000, 1000, dat, 1000, 100, 64)
+    private val settings = getDefaultInternalSettings(dat)
     private var shork = InternalShork(settings)
     private var program = Program("sne", shork)
     private var process = Process(program, 0)

--- a/backend/shork/src/test/kotlin/instruction/TestSne.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestSne.kt
@@ -14,7 +14,7 @@ import software.shonk.interpreter.internal.settings.InternalSettings
 
 internal class TestSne {
     private val dat = Dat(0, 0, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
-    private val settings = InternalSettings(8000, 1000, dat, 1000, 100)
+    private val settings = InternalSettings(8000, 1000, dat, 1000, 100, 64)
     private var shork = InternalShork(settings)
     private var program = Program("sne", shork)
     private var process = Process(program, 0)

--- a/backend/shork/src/test/kotlin/instruction/TestSpl.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestSpl.kt
@@ -1,5 +1,6 @@
 package instruction
 
+import getDefaultInternalSettings
 import kotlin.test.assertEquals
 import mocks.MockGameDataCollector
 import org.junit.jupiter.api.BeforeEach
@@ -11,20 +12,10 @@ import software.shonk.interpreter.internal.instruction.Dat
 import software.shonk.interpreter.internal.instruction.Spl
 import software.shonk.interpreter.internal.process.Process
 import software.shonk.interpreter.internal.program.Program
-import software.shonk.interpreter.internal.settings.InternalSettings
 
 internal class TestSpl {
     val dat = Dat(0, 0, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
-    val settings =
-        InternalSettings(
-            8000,
-            1000,
-            dat,
-            1000,
-            100,
-            64,
-            gameDataCollector = MockGameDataCollector(),
-        )
+    val settings = getDefaultInternalSettings(dat, gameDataCollector = MockGameDataCollector())
     var shork = InternalShork(settings)
 
     @BeforeEach

--- a/backend/shork/src/test/kotlin/instruction/TestSpl.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestSpl.kt
@@ -16,7 +16,15 @@ import software.shonk.interpreter.internal.settings.InternalSettings
 internal class TestSpl {
     val dat = Dat(0, 0, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
     val settings =
-        InternalSettings(8000, 1000, dat, 1000, 100, gameDataCollector = MockGameDataCollector())
+        InternalSettings(
+            8000,
+            1000,
+            dat,
+            1000,
+            100,
+            64,
+            gameDataCollector = MockGameDataCollector(),
+        )
     var shork = InternalShork(settings)
 
     @BeforeEach

--- a/backend/shork/src/test/kotlin/instruction/TestSub.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestSub.kt
@@ -15,7 +15,7 @@ import software.shonk.interpreter.internal.settings.InternalSettings
 internal class TestSub {
 
     private val dat = Dat(5, 7, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
-    private val settings = InternalSettings(8000, 1000, dat, 1000, 100)
+    private val settings = InternalSettings(8000, 1000, dat, 1000, 100, 64)
     private var shork = InternalShork(settings)
     private var program = Program("sub", shork)
     private var process = Process(program, 0)

--- a/backend/shork/src/test/kotlin/instruction/TestSub.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestSub.kt
@@ -1,5 +1,6 @@
 package instruction
 
+import getDefaultInternalSettings
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -10,12 +11,11 @@ import software.shonk.interpreter.internal.instruction.Dat
 import software.shonk.interpreter.internal.instruction.Sub
 import software.shonk.interpreter.internal.process.Process
 import software.shonk.interpreter.internal.program.Program
-import software.shonk.interpreter.internal.settings.InternalSettings
 
 internal class TestSub {
 
     private val dat = Dat(5, 7, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
-    private val settings = InternalSettings(8000, 1000, dat, 1000, 100, 64)
+    private val settings = getDefaultInternalSettings(dat)
     private var shork = InternalShork(settings)
     private var program = Program("sub", shork)
     private var process = Process(program, 0)

--- a/backend/shork/src/test/kotlin/memory/TestMemoryCore.kt
+++ b/backend/shork/src/test/kotlin/memory/TestMemoryCore.kt
@@ -71,7 +71,7 @@ internal class TestMemoryCore {
 
     @Test
     fun `test if the memory core integrates with the Game Data Collector`() {
-        val shork = InternalShork(InternalSettings(8000, 1000, defaultInstruction, 1000, 100))
+        val shork = InternalShork(InternalSettings(8000, 1000, defaultInstruction, 1000, 100, 64))
         val memoryCore = shork.memoryCore
         val gameDataCollector = shork.gameDataCollector
         val program = Program("Test", shork)

--- a/backend/shork/src/test/kotlin/memory/TestMemoryCore.kt
+++ b/backend/shork/src/test/kotlin/memory/TestMemoryCore.kt
@@ -61,8 +61,8 @@ internal class TestMemoryCore {
         val memoryCore = MemoryCore(10, settings)
 
         val instruction = MockInstruction(1, 2, AddressMode.DIRECT, AddressMode.DIRECT, Modifier.I)
-        memoryCore.storeAbsolute(-20, instruction)
-        val out = memoryCore.loadAbsolute(20)
+        memoryCore.storeAbsolute(-13, instruction)
+        val out = memoryCore.loadAbsolute(7)
 
         assertNotEquals(defaultInstruction, out)
         assertEquals(instruction, out)

--- a/backend/shork/src/test/kotlin/memory/TestMemoryCore.kt
+++ b/backend/shork/src/test/kotlin/memory/TestMemoryCore.kt
@@ -1,5 +1,6 @@
 package memory
 
+import getDefaultInternalSettings
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import mocks.MockGameDataCollector
@@ -16,13 +17,14 @@ import software.shonk.interpreter.internal.settings.InternalSettings
 internal class TestMemoryCore {
     val defaultInstruction =
         MockInstruction(42, 69, AddressMode.DIRECT, AddressMode.DIRECT, Modifier.I)
-    var memoryCore =
-        MemoryCore(8000, defaultInstruction = defaultInstruction, MockGameDataCollector())
+    val settings =
+        getDefaultInternalSettings(defaultInstruction, gameDataCollector = MockGameDataCollector())
+
+    var memoryCore = MemoryCore(8000, settings)
 
     @BeforeEach
     fun setup() {
-        memoryCore =
-            MemoryCore(8000, defaultInstruction = defaultInstruction, MockGameDataCollector())
+        memoryCore = MemoryCore(8000, settings)
     }
 
     @Test
@@ -45,8 +47,7 @@ internal class TestMemoryCore {
 
     @Test
     fun testReadWriteOutOfBoundsPositive() {
-        val memoryCore =
-            MemoryCore(10, defaultInstruction = defaultInstruction, MockGameDataCollector())
+        val memoryCore = MemoryCore(10, settings)
 
         val instruction = MockInstruction(1, 2, AddressMode.DIRECT, AddressMode.DIRECT, Modifier.I)
         memoryCore.storeAbsolute(20, instruction)
@@ -58,8 +59,7 @@ internal class TestMemoryCore {
 
     @Test
     fun testReadWriteOutOfBoundsNegative() {
-        val memoryCore =
-            MemoryCore(10, defaultInstruction = defaultInstruction, MockGameDataCollector())
+        val memoryCore = MemoryCore(10, settings)
 
         val instruction = MockInstruction(1, 2, AddressMode.DIRECT, AddressMode.DIRECT, Modifier.I)
         memoryCore.storeAbsolute(-20, instruction)

--- a/backend/shork/src/test/kotlin/process/TestProcess.kt
+++ b/backend/shork/src/test/kotlin/process/TestProcess.kt
@@ -23,6 +23,7 @@ internal class TestProcess {
             MockInstruction(),
             1000,
             100,
+            64,
             gameDataCollector = MockGameDataCollector(),
         )
     private var shork = InternalShork(settings)
@@ -85,7 +86,7 @@ internal class TestProcess {
     @Test
     fun `test if process integrates with the Game Data Collector`() {
         val dat = Dat(0, 0, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
-        val settings = InternalSettings(8000, 1000, dat, 1000, 100)
+        val settings = InternalSettings(8000, 1000, dat, 1000, 100, 64)
         shork = InternalShork(settings)
         val gameDataCollector = shork.gameDataCollector
 

--- a/backend/shork/src/test/kotlin/process/TestProcess.kt
+++ b/backend/shork/src/test/kotlin/process/TestProcess.kt
@@ -1,6 +1,7 @@
 package process
 
 import assertExecutionCountAtAddress
+import getDefaultInternalSettings
 import kotlin.test.assertEquals
 import mocks.MockGameDataCollector
 import mocks.MockInstruction
@@ -13,19 +14,10 @@ import software.shonk.interpreter.internal.addressing.Modifier
 import software.shonk.interpreter.internal.instruction.Dat
 import software.shonk.interpreter.internal.instruction.Jmp
 import software.shonk.interpreter.internal.program.Program
-import software.shonk.interpreter.internal.settings.InternalSettings
 
 internal class TestProcess {
     private var settings =
-        InternalSettings(
-            8000,
-            100,
-            MockInstruction(),
-            1000,
-            100,
-            64,
-            gameDataCollector = MockGameDataCollector(),
-        )
+        getDefaultInternalSettings(MockInstruction(), gameDataCollector = MockGameDataCollector())
     private var shork = InternalShork(settings)
     private var program = Program("id", shork)
 
@@ -86,7 +78,7 @@ internal class TestProcess {
     @Test
     fun `test if process integrates with the Game Data Collector`() {
         val dat = Dat(0, 0, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
-        val settings = InternalSettings(8000, 1000, dat, 1000, 100, 64)
+        val settings = getDefaultInternalSettings(dat)
         shork = InternalShork(settings)
         val gameDataCollector = shork.gameDataCollector
 

--- a/backend/shork/src/test/kotlin/program/TestProgram.kt
+++ b/backend/shork/src/test/kotlin/program/TestProgram.kt
@@ -22,6 +22,7 @@ internal class TestProgram {
             MockInstruction(),
             1000,
             100,
+            64,
             gameDataCollector = MockGameDataCollector(),
         )
     private var shork = InternalShork(settings)
@@ -165,7 +166,7 @@ internal class TestProgram {
     @Test
     fun `test if program integrates with game data collector`() {
         val dat = Dat(1, 1, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
-        val settings = InternalSettings(8000, 100, dat, 1000, 100)
+        val settings = InternalSettings(8000, 100, dat, 1000, 100, 64)
         val jmp = Jmp(42, 0, AddressMode.DIRECT, AddressMode.IMMEDIATE, Modifier.A)
 
         shork = InternalShork(settings)
@@ -187,5 +188,41 @@ internal class TestProgram {
         assertEquals(42, result.programCounterAfter)
         assertEquals(false, result.processDied)
         assertEquals(listOf(420, 4200), result.programCountersOfOtherProcesses)
+    }
+
+    fun testCreateProcessWithMaximumProcesses() {
+        val settings = InternalSettings(8000, 100, MockInstruction(), 1000, 100, 2)
+        val shork = InternalShork(settings)
+        val program = Program("id", shork)
+
+        program.createProcessAt(42)
+        assertEquals(1, program.processes.size())
+
+        program.createProcessAt(69)
+        assertEquals(2, program.processes.size())
+
+        program.createProcessAt(420)
+        assertEquals(2, program.processes.size())
+    }
+
+    @Test
+    fun testRemoveAndCreateProcessWithMaximumProcesses() {
+        val settings = InternalSettings(8000, 100, MockInstruction(), 1000, 100, 2)
+        val shork = InternalShork(settings)
+        val program = Program("id", shork)
+
+        program.createProcessAt(42)
+        program.createProcessAt(69)
+        program.createProcessAt(420)
+        assertEquals(2, program.processes.size())
+
+        program.removeProcess(program.processes.get())
+        assertEquals(1, program.processes.size())
+
+        program.createProcessAt(420)
+        assertEquals(2, program.processes.size())
+
+        program.createProcessAt(720)
+        assertEquals(2, program.processes.size())
     }
 }

--- a/backend/shork/src/test/kotlin/program/TestProgram.kt
+++ b/backend/shork/src/test/kotlin/program/TestProgram.kt
@@ -1,6 +1,7 @@
 package program
 
 import assertExecutionCountAtAddress
+import getDefaultInternalSettings
 import kotlin.test.assertEquals
 import mocks.MockGameDataCollector
 import mocks.MockInstruction
@@ -12,19 +13,10 @@ import software.shonk.interpreter.internal.addressing.Modifier
 import software.shonk.interpreter.internal.instruction.Dat
 import software.shonk.interpreter.internal.instruction.Jmp
 import software.shonk.interpreter.internal.program.Program
-import software.shonk.interpreter.internal.settings.InternalSettings
 
 internal class TestProgram {
     private var settings =
-        InternalSettings(
-            8000,
-            100,
-            MockInstruction(),
-            1000,
-            100,
-            64,
-            gameDataCollector = MockGameDataCollector(),
-        )
+        getDefaultInternalSettings(MockInstruction(), gameDataCollector = MockGameDataCollector())
     private var shork = InternalShork(settings)
     private var program = Program("id", shork)
 
@@ -166,7 +158,7 @@ internal class TestProgram {
     @Test
     fun `test if program integrates with game data collector`() {
         val dat = Dat(1, 1, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
-        val settings = InternalSettings(8000, 100, dat, 1000, 100, 64)
+        val settings = getDefaultInternalSettings(dat)
         val jmp = Jmp(42, 0, AddressMode.DIRECT, AddressMode.IMMEDIATE, Modifier.A)
 
         shork = InternalShork(settings)
@@ -191,7 +183,7 @@ internal class TestProgram {
     }
 
     fun testCreateProcessWithMaximumProcesses() {
-        val settings = InternalSettings(8000, 100, MockInstruction(), 1000, 100, 2)
+        val settings = getDefaultInternalSettings(MockInstruction(), maximumProcessesPerPlayer = 2)
         val shork = InternalShork(settings)
         val program = Program("id", shork)
 
@@ -207,7 +199,7 @@ internal class TestProgram {
 
     @Test
     fun testRemoveAndCreateProcessWithMaximumProcesses() {
-        val settings = InternalSettings(8000, 100, MockInstruction(), 1000, 100, 2)
+        val settings = getDefaultInternalSettings(MockInstruction(), maximumProcessesPerPlayer = 2)
         val shork = InternalShork(settings)
         val program = Program("id", shork)
 


### PR DESCRIPTION
There were some issues testing options
- initialProgramCount
- seperation
Both are only used in the `Shork`s `run` method. Because the MemoryCore gets initiated at the start of the function and all references dropped at the end, we can only observe who won when calling `run`.
@flamion and I agreed to open a new Issue for testing `seperation`, as the way `run` works should change soon and testing `seperation` might be possible afterward. 

The way address resolving works had to be changed substantially because of the `readDistance` and `writeDistance` settings.  
(Because of this, each time a new instruction is implemented, I will have to alter this PR. So do not merge right after merging of a new instruction)