### PR TITLE
[#235] Fix SEQ.I Comparison to not compare address modes

### DIFF
--- a/backend/shork/src/main/kotlin/internal/instruction/Seq.kt
+++ b/backend/shork/src/main/kotlin/internal/instruction/Seq.kt
@@ -41,7 +41,10 @@ internal class Seq(
                         sourceInstruction.bField == destinationInstruction.aField
                 }
                 Modifier.I -> {
-                    sourceInstruction == destinationInstruction
+                    sourceInstruction::class == destinationInstruction::class &&
+                        sourceInstruction.aField == destinationInstruction.aField &&
+                        sourceInstruction.bField == destinationInstruction.bField &&
+                        sourceInstruction.modifier == destinationInstruction.modifier
                 }
             }
 

--- a/backend/shork/src/test/kotlin/instruction/TestSeq.kt
+++ b/backend/shork/src/test/kotlin/instruction/TestSeq.kt
@@ -37,8 +37,14 @@ internal class TestSeq {
         return seq
     }
 
-    private fun setupMemory(aField: Int, bField: Int, address: Int) {
-        val dat = Dat(aField, bField, AddressMode.IMMEDIATE, AddressMode.IMMEDIATE, Modifier.A)
+    private fun setupMemory(
+        aField: Int,
+        bField: Int,
+        address: Int,
+        addressModeA: AddressMode = AddressMode.DIRECT,
+        addressModeB: AddressMode = AddressMode.DIRECT,
+    ) {
+        val dat = Dat(aField, bField, addressModeA, addressModeB, Modifier.A)
         shork.memoryCore.storeAbsolute(address, dat)
     }
 
@@ -99,6 +105,14 @@ internal class TestSeq {
         val seq = setupSeq(Modifier.I)
         setupMemory(42, 69, 1)
         setupMemory(42, 69, 2)
+        executeSeqAndAssertCounter(seq, 1)
+    }
+
+    @Test
+    fun `test modifier I equal different address modes`() {
+        val seq = setupSeq(Modifier.I)
+        setupMemory(42, 69, 1, AddressMode.IMMEDIATE, AddressMode.B_INDIRECT)
+        setupMemory(42, 69, 2, AddressMode.A_INDIRECT, AddressMode.DIRECT)
         executeSeqAndAssertCounter(seq, 1)
     }
 


### PR DESCRIPTION
![speed](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fmedia1.tenor.com%2Fimages%2F940e1ede73e2c5e67103f66550780b06%2Ftenor.gif%3Fitemid%3D14031767&f=1&nofb=1&ipt=0deb85f2e2964c6c8734eea7c842b6e10b3b90d33644738d356b55134599a0ae&ipo=images)