### PR TITLE
Bug fix: POST with missing lobby response to 404

### DIFF
--- a/backend/api/src/main/kotlin/software/shonk/adapters/incoming/ShorkInterpreterController.kt
+++ b/backend/api/src/main/kotlin/software/shonk/adapters/incoming/ShorkInterpreterController.kt
@@ -97,6 +97,11 @@ fun Route.configureShorkInterpreterControllerV1() {
 
         val player = call.parameters["player"]
         val submitCodeRequest = call.receive<SubmitCodeRequest>()
+
+        if (shorkUseCase.getLobbyStatus(lobbyId).isFailure) {
+            return@post call.respond(HttpStatusCode.NotFound)
+        }
+
         val result = shorkUseCase.addProgramToLobby(lobbyId, player, submitCodeRequest.code)
 
         result.onFailure {

--- a/backend/api/src/test/kotlin/software/shonk/adapters/incoming/ShorkInterpreterControllerV1IT.kt
+++ b/backend/api/src/test/kotlin/software/shonk/adapters/incoming/ShorkInterpreterControllerV1IT.kt
@@ -1,6 +1,5 @@
 package software.shonk.adapters.incoming
 
-import io.ktor.client.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
@@ -8,7 +7,6 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.*
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
-import org.koin.dsl.module
 import software.shonk.domain.CompileError
 import software.shonk.domain.LobbyStatus
 import software.shonk.module
@@ -188,6 +186,17 @@ class ShorkInterpreterControllerV1IT : AbstractControllerTest() {
                 setBody("{\"code\":\"weDontCareWhatsInHereForThisTest\"}")
             }
         assertEquals(HttpStatusCode.OK, result.status)
+    }
+
+    @Test
+    fun `test player code submission in invalid lobby`() = runTest {
+        val player = "playerA"
+        val result =
+            client.post("/api/v1/lobby/0/code/$player") {
+                contentType(ContentType.Application.Json)
+                setBody("{\"code\":\"weDontCareWhatsInHereForThisTest\"}")
+            }
+        assertEquals(HttpStatusCode.NotFound, result.status)
     }
 
     @Test

--- a/backend/api/src/test/kotlin/software/shonk/adapters/incoming/ShorkInterpreterControllerV1IT.kt
+++ b/backend/api/src/test/kotlin/software/shonk/adapters/incoming/ShorkInterpreterControllerV1IT.kt
@@ -6,6 +6,7 @@ import io.ktor.http.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.*
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import software.shonk.domain.CompileError
 import software.shonk.domain.LobbyStatus
@@ -88,382 +89,443 @@ class ShorkInterpreterControllerV1IT : AbstractControllerTest() {
         return lobbiesArray.map { Json.decodeFromJsonElement<LobbyStatus>(it) }
     }
 
-    @Test
-    fun `test post and get player code`() = runTest {
-        client.post("/api/v1/lobby") {
-            contentType(ContentType.Application.Json)
-            setBody("{\"playerName\":\"playerA\"}")
-        }
-        client.post("/api/v1/lobby/0/code/playerA") {
-            contentType(ContentType.Application.Json)
-            setBody("{\"code\": \"someString\"}")
-        }
-
-        client.post("/api/v1/lobby/0/code/playerB") {
-            contentType(ContentType.Application.Json)
-            setBody("{\"code\": \"someOtherString\"}")
-        }
-
-        val result = client.get("/api/v1/lobby/0/code/playerA")
-        assertEquals(
-            "someString",
-            Json.parseToJsonElement(result.bodyAsText()).jsonObject["code"]?.jsonPrimitive?.content,
-        )
-
-        val resultB = client.get("/api/v1/lobby/0/code/playerB")
-        assertEquals(
-            "someOtherString",
-            Json.parseToJsonElement(resultB.bodyAsText()).jsonObject["code"]?.jsonPrimitive?.content,
-        )
-    }
-
-    @Test
-    fun testGetPlayerCodeNotSubmitted() = runTest {
-        client.post("/api/v1/lobby") {
-            contentType(ContentType.Application.Json)
-            setBody("{\"playerName\":\"playerA\"}")
-        }
-        val result = client.get("/api/v1/lobby/0/code/playerA")
-        assertEquals(HttpStatusCode.BadRequest, result.status)
-        assert(result.bodyAsText().contains("No player with that name in the lobby"))
-    }
-
-    @Test
-    fun `test get lobby status with invalid ID`() = runTest {
-        val result = client.get("/api/v1/lobby/1/status")
-        assertEquals(HttpStatusCode.BadRequest, result.status)
-        assert(result.bodyAsText().contains("No lobby with that id"))
-    }
-
-    @Test
-    fun `test get lobby status with valid default ID`() = runTest {
-        client.post("/api/v1/lobby") {
-            contentType(ContentType.Application.Json)
-            setBody("{\"playerName\":\"playerA\"}")
-        }
-        val result = client.get("/api/v1/lobby/0/status")
-        val responseData = parseStatus(result)
-        assertEquals("false", responseData["playerASubmitted"])
-        assertEquals("false", responseData["playerBSubmitted"])
-        assertEquals("NOT_STARTED", responseData["gameState"])
-        assertEquals("DRAW", responseData["result.winner"])
-    }
-
-    @Test
-    fun `test get lobby status with valid custom ID`() = runTest {
-        client.post("/api/v1/lobby") {
-            contentType(ContentType.Application.Json)
-            setBody("{\"playerName\":\"playerA\"}")
-        }
-        client.post("/api/v1/lobby/0/code/playerA") {
-            contentType(ContentType.Application.Json)
-            setBody("{\"code\":\"someString\"}")
-        }
-
-        client.post("/api/v1/lobby/0/code/playerB") {
-            contentType(ContentType.Application.Json)
-            setBody("{\"code\":\"someOtherString\"}")
-        }
-
-        val result = client.get("/api/v1/lobby/0/status")
-        val responseData = parseStatus(result)
-        assertEquals("true", responseData["playerASubmitted"])
-        assertEquals("true", responseData["playerBSubmitted"])
-        assertEquals("FINISHED", responseData["gameState"])
-        assertEquals("B", responseData["result.winner"])
-    }
-
-    @Test
-    fun `test player empty code submission`() = runTest {
-        client.post("/api/v1/lobby") {
-            contentType(ContentType.Application.Json)
-            setBody("{\"playerName\":\"playerA\"}")
-        }
-        val player = "playerA"
-        val result =
-            client.post("/api/v1/lobby/0/code/$player") {
-                contentType(ContentType.Application.Json)
-                setBody("{\"code\":\"weDontCareWhatsInHereForThisTest\"}")
-            }
-        assertEquals(HttpStatusCode.OK, result.status)
-    }
-
-    @Test
-    fun `test player code submission in invalid lobby`() = runTest {
-        val player = "playerA"
-        val result =
-            client.post("/api/v1/lobby/0/code/$player") {
-                contentType(ContentType.Application.Json)
-                setBody("{\"code\":\"weDontCareWhatsInHereForThisTest\"}")
-            }
-        assertEquals(HttpStatusCode.NotFound, result.status)
-    }
-
-    @Test
-    fun `test player code submission with invalid username does not change lobby status`() =
-        runTest {
+    @Nested
+    inner class ReadAndWritePlayerCode {
+        @Test
+        fun `test post and get player code`() = runTest {
             client.post("/api/v1/lobby") {
                 contentType(ContentType.Application.Json)
                 setBody("{\"playerName\":\"playerA\"}")
             }
-            val player = "playerC"
-            client.post("/api/v1/lobby/0/code/$player") {
+            client.post("/api/v1/lobby/0/code/playerA") {
                 contentType(ContentType.Application.Json)
-                setBody("someString")
+                setBody("{\"code\": \"someString\"}")
             }
 
-            val result = client.get("/api/v1/lobby/0/code/playerC")
+            client.post("/api/v1/lobby/0/code/playerB") {
+                contentType(ContentType.Application.Json)
+                setBody("{\"code\": \"someOtherString\"}")
+            }
+
+            val result = client.get("/api/v1/lobby/0/code/playerA")
+            assertEquals(
+                "someString",
+                Json.parseToJsonElement(result.bodyAsText())
+                    .jsonObject["code"]
+                    ?.jsonPrimitive
+                    ?.content,
+            )
+
+            val resultB = client.get("/api/v1/lobby/0/code/playerB")
+            assertEquals(
+                "someOtherString",
+                Json.parseToJsonElement(resultB.bodyAsText())
+                    .jsonObject["code"]
+                    ?.jsonPrimitive
+                    ?.content,
+            )
+        }
+
+        @Test
+        fun testGetPlayerCodeNotSubmitted() = runTest {
+            client.post("/api/v1/lobby") {
+                contentType(ContentType.Application.Json)
+                setBody("{\"playerName\":\"playerA\"}")
+            }
+            val result = client.get("/api/v1/lobby/0/code/playerA")
             assertEquals(HttpStatusCode.BadRequest, result.status)
             assert(result.bodyAsText().contains("No player with that name in the lobby"))
+        }
 
-            val resultStatus = client.get("/api/v1/lobby/0/status")
-            val responseData = parseStatus(resultStatus)
+        @Test
+        fun `test player empty code submission`() = runTest {
+            client.post("/api/v1/lobby") {
+                contentType(ContentType.Application.Json)
+                setBody("{\"playerName\":\"playerA\"}")
+            }
+            val player = "playerA"
+            val result =
+                client.post("/api/v1/lobby/0/code/$player") {
+                    contentType(ContentType.Application.Json)
+                    setBody("{\"code\":\"weDontCareWhatsInHereForThisTest\"}")
+                }
+            assertEquals(HttpStatusCode.OK, result.status)
+        }
+
+        @Test
+        fun `test player code submission in invalid lobby`() = runTest {
+            val player = "playerA"
+            val result =
+                client.post("/api/v1/lobby/0/code/$player") {
+                    contentType(ContentType.Application.Json)
+                    setBody("{\"code\":\"weDontCareWhatsInHereForThisTest\"}")
+                }
+            assertEquals(HttpStatusCode.NotFound, result.status)
+        }
+
+        @Test
+        fun `test player code submission with invalid username does not change lobby status`() =
+            runTest {
+                client.post("/api/v1/lobby") {
+                    contentType(ContentType.Application.Json)
+                    setBody("{\"playerName\":\"playerA\"}")
+                }
+                val player = "playerC"
+                client.post("/api/v1/lobby/0/code/$player") {
+                    contentType(ContentType.Application.Json)
+                    setBody("someString")
+                }
+
+                val result = client.get("/api/v1/lobby/0/code/playerC")
+                assertEquals(HttpStatusCode.BadRequest, result.status)
+                assert(result.bodyAsText().contains("No player with that name in the lobby"))
+
+                val resultStatus = client.get("/api/v1/lobby/0/status")
+                val responseData = parseStatus(resultStatus)
+                assertEquals("false", responseData["playerASubmitted"])
+                assertEquals("false", responseData["playerBSubmitted"])
+                assertEquals("NOT_STARTED", responseData["gameState"])
+                assertEquals("DRAW", responseData["result.winner"])
+            }
+
+        @Test
+        fun `test player code submission reflecting in lobby status`() = runTest {
+            client.post("/api/v1/lobby") {
+                contentType(ContentType.Application.Json)
+                setBody("{\"playerName\":\"playerA\"}")
+            }
+            val player = "playerA"
+            client.post("/api/v1/lobby/0/code/$player") {
+                contentType(ContentType.Application.Json)
+                setBody("{\"code\":\"someString\"}")
+            }
+
+            val result = client.get("/api/v1/lobby/0/status")
+            val responseData = parseStatus(result)
+            assertEquals("true", responseData["playerASubmitted"])
+            assertEquals("false", responseData["playerBSubmitted"])
+            assertEquals("NOT_STARTED", responseData["gameState"])
+            assertEquals("DRAW", responseData["result.winner"])
+        }
+
+        @Test
+        fun `test game starts when both players submit`() = runTest {
+            client.post("/api/v1/lobby") {
+                contentType(ContentType.Application.Json)
+                setBody("{\"playerName\":\"playerA\"}")
+            }
+            client.post("/api/v1/lobby/0/code/playerA") {
+                contentType(ContentType.Application.Json)
+                setBody("{\"code\":\"someVeryLongString\"}")
+            }
+
+            client.post("/api/v1/lobby/0/code/playerB") {
+                contentType(ContentType.Application.Json)
+                setBody("{\"code\":\"someShortString\"}")
+            }
+
+            val result = client.get("/api/v1/lobby/0/status")
+            val responseData = parseStatus(result)
+            assertEquals("FINISHED", responseData["gameState"])
+        }
+
+        @Test
+        fun `test lobby status resets after new code submission by player A`() = runTest {
+            client.post("/api/v1/lobby") {
+                contentType(ContentType.Application.Json)
+                setBody("{\"playerName\":\"playerA\"}")
+            }
+            client.post("/api/v1/lobby/0/code/playerA") {
+                contentType(ContentType.Application.Json)
+                setBody("{\"code\":\"someString\"}")
+            }
+
+            client.post("/api/v1/lobby/0/code/playerB") {
+                contentType(ContentType.Application.Json)
+                setBody("{\"code\":\"someOtherString\"}")
+            }
+            client.post("/api/v1/lobby/0/code/playerA") {
+                contentType(ContentType.Application.Json)
+                setBody("{\"code\":\"someNewString\"}")
+            }
+
+            val result = client.get("/api/v1/lobby/0/status")
+            val responseData = parseStatus(result)
+            assertEquals("true", responseData["playerASubmitted"])
+            assertEquals("false", responseData["playerBSubmitted"])
+            assertEquals("NOT_STARTED", responseData["gameState"])
+            assertEquals("DRAW", responseData["result.winner"])
+        }
+    }
+
+    @Nested
+    inner class GetLobbyStatus {
+        @Test
+        fun `test get lobby status with invalid ID`() = runTest {
+            val result = client.get("/api/v1/lobby/1/status")
+            assertEquals(HttpStatusCode.BadRequest, result.status)
+            assert(result.bodyAsText().contains("No lobby with that id"))
+        }
+
+        @Test
+        fun `test get lobby status with valid default ID`() = runTest {
+            client.post("/api/v1/lobby") {
+                contentType(ContentType.Application.Json)
+                setBody("{\"playerName\":\"playerA\"}")
+            }
+            val result = client.get("/api/v1/lobby/0/status")
+            val responseData = parseStatus(result)
             assertEquals("false", responseData["playerASubmitted"])
             assertEquals("false", responseData["playerBSubmitted"])
             assertEquals("NOT_STARTED", responseData["gameState"])
             assertEquals("DRAW", responseData["result.winner"])
         }
 
-    @Test
-    fun `test player code submission reflecting in lobby status`() = runTest {
-        client.post("/api/v1/lobby") {
-            contentType(ContentType.Application.Json)
-            setBody("{\"playerName\":\"playerA\"}")
-        }
-        val player = "playerA"
-        client.post("/api/v1/lobby/0/code/$player") {
-            contentType(ContentType.Application.Json)
-            setBody("{\"code\":\"someString\"}")
-        }
-
-        val result = client.get("/api/v1/lobby/0/status")
-        val responseData = parseStatus(result)
-        assertEquals("true", responseData["playerASubmitted"])
-        assertEquals("false", responseData["playerBSubmitted"])
-        assertEquals("NOT_STARTED", responseData["gameState"])
-        assertEquals("DRAW", responseData["result.winner"])
-    }
-
-    @Test
-    fun `test game starts when both players submit`() = runTest {
-        client.post("/api/v1/lobby") {
-            contentType(ContentType.Application.Json)
-            setBody("{\"playerName\":\"playerA\"}")
-        }
-        client.post("/api/v1/lobby/0/code/playerA") {
-            contentType(ContentType.Application.Json)
-            setBody("{\"code\":\"someVeryLongString\"}")
-        }
-
-        client.post("/api/v1/lobby/0/code/playerB") {
-            contentType(ContentType.Application.Json)
-            setBody("{\"code\":\"someShortString\"}")
-        }
-
-        val result = client.get("/api/v1/lobby/0/status")
-        val responseData = parseStatus(result)
-        assertEquals("FINISHED", responseData["gameState"])
-    }
-
-    @Test
-    fun `test lobby status resets after new code submission by player A`() = runTest {
-        client.post("/api/v1/lobby") {
-            contentType(ContentType.Application.Json)
-            setBody("{\"playerName\":\"playerA\"}")
-        }
-        client.post("/api/v1/lobby/0/code/playerA") {
-            contentType(ContentType.Application.Json)
-            setBody("{\"code\":\"someString\"}")
-        }
-
-        client.post("/api/v1/lobby/0/code/playerB") {
-            contentType(ContentType.Application.Json)
-            setBody("{\"code\":\"someOtherString\"}")
-        }
-        client.post("/api/v1/lobby/0/code/playerA") {
-            contentType(ContentType.Application.Json)
-            setBody("{\"code\":\"someNewString\"}")
-        }
-
-        val result = client.get("/api/v1/lobby/0/status")
-        val responseData = parseStatus(result)
-        assertEquals("true", responseData["playerASubmitted"])
-        assertEquals("false", responseData["playerBSubmitted"])
-        assertEquals("NOT_STARTED", responseData["gameState"])
-        assertEquals("DRAW", responseData["result.winner"])
-    }
-
-    @Test
-    fun `test create a new lobby with playerName`() = runTest {
-        val result =
+        @Test
+        fun `test get lobby status with valid custom ID`() = runTest {
             client.post("/api/v1/lobby") {
                 contentType(ContentType.Application.Json)
                 setBody("{\"playerName\":\"playerA\"}")
             }
-        assertEquals(HttpStatusCode.Created, result.status)
-        val responseId =
-            Json.parseToJsonElement(result.bodyAsText())
-                .jsonObject["lobbyId"]!!
-                .jsonPrimitive
-                .content
-        assertEquals("0", responseId)
-    }
-
-    @Test
-    fun `test create a multiple new lobbies`() = runTest {
-        val result =
-            client.post("/api/v1/lobby") {
+            client.post("/api/v1/lobby/0/code/playerA") {
                 contentType(ContentType.Application.Json)
-                setBody("{\"playerName\":\"playerA\"}")
-            }
-        val result2 =
-            client.post("/api/v1/lobby") {
-                contentType(ContentType.Application.Json)
-                setBody("{\"playerName\":\"playerB\"}")
-            }
-        val result3 =
-            client.post("/api/v1/lobby") {
-                contentType(ContentType.Application.Json)
-                setBody("{\"playerName\":\"playerC\"}")
-            }
-        assertEquals(HttpStatusCode.Created, result.status)
-        val responseId0 =
-            Json.parseToJsonElement(result.bodyAsText())
-                .jsonObject["lobbyId"]!!
-                .jsonPrimitive
-                .content
-        assertEquals("0", responseId0)
-        assertEquals(HttpStatusCode.Created, result2.status)
-        val responseId1 =
-            Json.parseToJsonElement(result2.bodyAsText())
-                .jsonObject["lobbyId"]!!
-                .jsonPrimitive
-                .content
-        assertEquals("1", responseId1)
-        assertEquals(HttpStatusCode.Created, result3.status)
-        val responseId2 =
-            Json.parseToJsonElement(result3.bodyAsText())
-                .jsonObject["lobbyId"]!!
-                .jsonPrimitive
-                .content
-        assertEquals("2", responseId2)
-    }
-
-    @Test
-    fun `test create a new lobby with invalid playerName`() = runTest {
-        val result =
-            client.post("/api/v1/lobby") {
-                contentType(ContentType.Application.Json)
-                setBody("{\"playerName\":\"\"}")
-            }
-        assertEquals(HttpStatusCode.BadRequest, result.status)
-        assertEquals("Your player name is invalid", result.bodyAsText())
-    }
-
-    @Test
-    fun `test body with invalid json`() = runTest {
-        val result =
-            client.post("/api/v1/lobby") {
-                contentType(ContentType.Application.Json)
-                setBody("{ invalid, : json :3")
-            }
-        assertEquals(HttpStatusCode.BadRequest, result.status)
-    }
-
-    @Test
-    fun `test body with playername null`() = runTest {
-        val result =
-            client.post("/api/v1/lobby") {
-                contentType(ContentType.Application.Json)
-                setBody("{ }")
+                setBody("{\"code\":\"someString\"}")
             }
 
-        assertEquals(HttpStatusCode.BadRequest, result.status)
-    }
-
-    @Test
-    fun `test join lobby with valid playerName`() = runTest {
-        client.post("/api/v1/lobby") {
-            contentType(ContentType.Application.Json)
-            setBody("{\"playerName\":\"playerA\"}")
-        }
-        val result =
-            client.post("/api/v1/lobby/0/join") {
+            client.post("/api/v1/lobby/0/code/playerB") {
                 contentType(ContentType.Application.Json)
-                setBody("{\"playerName\":\"playerB\"}")
+                setBody("{\"code\":\"someOtherString\"}")
             }
-        assertEquals(HttpStatusCode.OK, result.status)
-    }
 
-    @Test
-    fun `test join lobby with duplicate (invalid) playerName`() = runTest {
-        client.post("/api/v1/lobby") {
-            contentType(ContentType.Application.Json)
-            setBody("{\"playerName\":\"playerA\"}")
-        }
-        val result =
-            client.post("/api/v1/lobby/0/join") {
-                contentType(ContentType.Application.Json)
-                setBody("{\"playerName\":\"playerA\"}")
-            }
-        assertEquals(HttpStatusCode.Conflict, result.status)
-    }
-
-    @Test
-    fun `test join lobby with invalid json`() = runTest {
-        client.post("/api/v1/lobby") {
-            contentType(ContentType.Application.Json)
-            setBody("{\"playerName\":\"playerA\"}")
-        }
-        val result =
-            client.post("/api/v1/lobby/0/join") {
-                contentType(ContentType.Application.Json)
-                setBody("{ invalid, : json :3")
-            }
-        assertEquals(HttpStatusCode.BadRequest, result.status)
-    }
-
-    @Test
-    fun `test join nonexistent lobby`() = runTest {
-        val result =
-            client.post("/api/v1/lobby/0/join") {
-                contentType(ContentType.Application.Json)
-                setBody("{\"playerName\":\"playerA\"}")
-            }
-        assertEquals(HttpStatusCode.NotFound, result.status)
-    }
-
-    @Test
-    fun `test get all lobbies when there is only one and it's not initialized`() = runTest {
-        client.post("/api/v1/lobby") {
-            contentType(ContentType.Application.Json)
-            setBody("{\"playerName\":\"playerA\"}")
+            val result = client.get("/api/v1/lobby/0/status")
+            val responseData = parseStatus(result)
+            assertEquals("true", responseData["playerASubmitted"])
+            assertEquals("true", responseData["playerBSubmitted"])
+            assertEquals("FINISHED", responseData["gameState"])
+            assertEquals("B", responseData["result.winner"])
         }
 
-        val result = client.get("/api/v1/lobby")
-        val parsedLobbies = parseAllLobbies(result)
+        @Test
+        fun `test if game visualization data is absent before any game round has run`() = runTest {
+            val joinLobbyResponse =
+                client.post("/api/v1/lobby") {
+                    contentType(ContentType.Application.Json)
+                    setBody(JoinLobbyRequest("playerA").json())
+                }
+            assertEquals(HttpStatusCode.Created, joinLobbyResponse.status)
 
-        assertEquals(HttpStatusCode.OK, result.status)
-        assertEquals(1, parsedLobbies.size)
+            val lobby =
+                Json.decodeFromString(
+                    JoinLobbyResponse.serializer(),
+                    joinLobbyResponse.bodyAsText(),
+                )
+            val lobbyId = lobby.lobbyId
 
-        assertTrue(
-            parsedLobbies.contains(
-                LobbyStatus(id = 0L, playersJoined = listOf("playerA"), gameState = "NOT_STARTED")
-            )
-        )
+            val lobbyStatusResponse = client.get("/api/v1/lobby/$lobbyId/status")
+            assertEquals(HttpStatusCode.OK, lobbyStatusResponse.status)
+
+            val lobbyStatus =
+                Json.decodeFromString(
+                    LobbyStatusResponse.serializer(),
+                    lobbyStatusResponse.bodyAsText(),
+                )
+            assertEquals(GameState.NOT_STARTED, lobbyStatus.gameState)
+            assertTrue(lobbyStatus.visualizationData.isEmpty())
+        }
+
+        @Test
+        fun `test if game visualization data is present after a game round has run`() = runTest {
+            val joinLobbyResponse =
+                client.post("/api/v1/lobby") {
+                    contentType(ContentType.Application.Json)
+                    setBody(JoinLobbyRequest("playerA").json())
+                }
+            assertEquals(HttpStatusCode.Created, joinLobbyResponse.status)
+
+            val lobby =
+                Json.decodeFromString(
+                    JoinLobbyResponse.serializer(),
+                    joinLobbyResponse.bodyAsText(),
+                )
+            val lobbyId = lobby.lobbyId
+
+            val playerACode =
+                client.post("/api/v1/lobby/$lobbyId/code/playerA") {
+                    contentType(ContentType.Application.Json)
+                    setBody(Program("MOV 0, 1").json())
+                }
+            assertEquals(HttpStatusCode.OK, playerACode.status)
+
+            val playerBCode =
+                client.post("/api/v1/lobby/$lobbyId/code/playerB") {
+                    contentType(ContentType.Application.Json)
+                    setBody(Program("MOV 0, 1").json())
+                }
+            assertEquals(HttpStatusCode.OK, playerBCode.status)
+
+            val lobbyStatusResponse = client.get("/api/v1/lobby/$lobbyId/status")
+            assertEquals(HttpStatusCode.OK, lobbyStatusResponse.status)
+
+            val lobbyStatus =
+                Json.decodeFromString(
+                    LobbyStatusResponse.serializer(),
+                    lobbyStatusResponse.bodyAsText(),
+                )
+            assertEquals(GameState.FINISHED, lobbyStatus.gameState)
+            assertTrue(lobbyStatus.visualizationData.isNotEmpty())
+        }
     }
 
-    @Test
-    fun `test get all lobbies as a list with players and games status for more than one lobby`() =
-        runTest {
+    @Nested
+    inner class CreateLobby {
+        @Test
+        fun `test create a new lobby with playerName`() = runTest {
+            val result =
+                client.post("/api/v1/lobby") {
+                    contentType(ContentType.Application.Json)
+                    setBody("{\"playerName\":\"playerA\"}")
+                }
+            assertEquals(HttpStatusCode.Created, result.status)
+            val responseId =
+                Json.parseToJsonElement(result.bodyAsText())
+                    .jsonObject["lobbyId"]!!
+                    .jsonPrimitive
+                    .content
+            assertEquals("0", responseId)
+        }
+
+        @Test
+        fun `test create a multiple new lobbies`() = runTest {
+            val result =
+                client.post("/api/v1/lobby") {
+                    contentType(ContentType.Application.Json)
+                    setBody("{\"playerName\":\"playerA\"}")
+                }
+            val result2 =
+                client.post("/api/v1/lobby") {
+                    contentType(ContentType.Application.Json)
+                    setBody("{\"playerName\":\"playerB\"}")
+                }
+            val result3 =
+                client.post("/api/v1/lobby") {
+                    contentType(ContentType.Application.Json)
+                    setBody("{\"playerName\":\"playerC\"}")
+                }
+            assertEquals(HttpStatusCode.Created, result.status)
+            val responseId0 =
+                Json.parseToJsonElement(result.bodyAsText())
+                    .jsonObject["lobbyId"]!!
+                    .jsonPrimitive
+                    .content
+            assertEquals("0", responseId0)
+            assertEquals(HttpStatusCode.Created, result2.status)
+            val responseId1 =
+                Json.parseToJsonElement(result2.bodyAsText())
+                    .jsonObject["lobbyId"]!!
+                    .jsonPrimitive
+                    .content
+            assertEquals("1", responseId1)
+            assertEquals(HttpStatusCode.Created, result3.status)
+            val responseId2 =
+                Json.parseToJsonElement(result3.bodyAsText())
+                    .jsonObject["lobbyId"]!!
+                    .jsonPrimitive
+                    .content
+            assertEquals("2", responseId2)
+        }
+
+        @Test
+        fun `test create a new lobby with invalid playerName`() = runTest {
+            val result =
+                client.post("/api/v1/lobby") {
+                    contentType(ContentType.Application.Json)
+                    setBody("{\"playerName\":\"\"}")
+                }
+            assertEquals(HttpStatusCode.BadRequest, result.status)
+            assertEquals("Your player name is invalid", result.bodyAsText())
+        }
+
+        @Test
+        fun `test create lobby with invalid json body`() = runTest {
+            val result =
+                client.post("/api/v1/lobby") {
+                    contentType(ContentType.Application.Json)
+                    setBody("{ invalid, : json :3")
+                }
+            assertEquals(HttpStatusCode.BadRequest, result.status)
+        }
+
+        @Test
+        fun `test create lobby with playername null`() = runTest {
+            val result =
+                client.post("/api/v1/lobby") {
+                    contentType(ContentType.Application.Json)
+                    setBody("{ }")
+                }
+
+            assertEquals(HttpStatusCode.BadRequest, result.status)
+        }
+    }
+
+    @Nested
+    inner class JoinLobby {
+        @Test
+        fun `test join lobby with valid playerName`() = runTest {
             client.post("/api/v1/lobby") {
                 contentType(ContentType.Application.Json)
                 setBody("{\"playerName\":\"playerA\"}")
             }
+            val result =
+                client.post("/api/v1/lobby/0/join") {
+                    contentType(ContentType.Application.Json)
+                    setBody("{\"playerName\":\"playerB\"}")
+                }
+            assertEquals(HttpStatusCode.OK, result.status)
+        }
+
+        @Test
+        fun `test join lobby with duplicate (invalid) playerName`() = runTest {
             client.post("/api/v1/lobby") {
                 contentType(ContentType.Application.Json)
                 setBody("{\"playerName\":\"playerA\"}")
             }
+            val result =
+                client.post("/api/v1/lobby/0/join") {
+                    contentType(ContentType.Application.Json)
+                    setBody("{\"playerName\":\"playerA\"}")
+                }
+            assertEquals(HttpStatusCode.Conflict, result.status)
+        }
+
+        @Test
+        fun `test join lobby with invalid json`() = runTest {
+            client.post("/api/v1/lobby") {
+                contentType(ContentType.Application.Json)
+                setBody("{\"playerName\":\"playerA\"}")
+            }
+            val result =
+                client.post("/api/v1/lobby/0/join") {
+                    contentType(ContentType.Application.Json)
+                    setBody("{ invalid, : json :3")
+                }
+            assertEquals(HttpStatusCode.BadRequest, result.status)
+        }
+
+        @Test
+        fun `test join nonexistent lobby`() = runTest {
+            val result =
+                client.post("/api/v1/lobby/0/join") {
+                    contentType(ContentType.Application.Json)
+                    setBody("{\"playerName\":\"playerA\"}")
+                }
+            assertEquals(HttpStatusCode.NotFound, result.status)
+        }
+    }
+
+    @Nested
+    inner class GetAllLobbies {
+        @Test
+        fun `test get all lobbies when there is only one and it's not initialized`() = runTest {
             client.post("/api/v1/lobby") {
                 contentType(ContentType.Application.Json)
                 setBody("{\"playerName\":\"playerA\"}")
@@ -473,7 +535,7 @@ class ShorkInterpreterControllerV1IT : AbstractControllerTest() {
             val parsedLobbies = parseAllLobbies(result)
 
             assertEquals(HttpStatusCode.OK, result.status)
-            assertEquals(3, parsedLobbies.size)
+            assertEquals(1, parsedLobbies.size)
 
             assertTrue(
                 parsedLobbies.contains(
@@ -484,124 +546,98 @@ class ShorkInterpreterControllerV1IT : AbstractControllerTest() {
                     )
                 )
             )
-
-            assertTrue(
-                parsedLobbies.contains(
-                    LobbyStatus(
-                        id = 1L,
-                        playersJoined = listOf("playerA"),
-                        gameState = "NOT_STARTED",
-                    )
-                )
-            )
-
-            assertTrue(
-                parsedLobbies.contains(
-                    LobbyStatus(
-                        id = 2L,
-                        playersJoined = listOf("playerA"),
-                        gameState = "NOT_STARTED",
-                    )
-                )
-            )
         }
 
-    @Test
-    fun `test compile invalid json`() = runTest {
-        val result =
-            client.post("/api/v1/redcode/compile/errors") {
-                contentType(ContentType.Application.Json)
-                setBody("{ invalid, : json >:3c")
-            }
+        @Test
+        fun `test get all lobbies as a list with players and games status for more than one lobby`() =
+            runTest {
+                client.post("/api/v1/lobby") {
+                    contentType(ContentType.Application.Json)
+                    setBody("{\"playerName\":\"playerA\"}")
+                }
+                client.post("/api/v1/lobby") {
+                    contentType(ContentType.Application.Json)
+                    setBody("{\"playerName\":\"playerA\"}")
+                }
+                client.post("/api/v1/lobby") {
+                    contentType(ContentType.Application.Json)
+                    setBody("{\"playerName\":\"playerA\"}")
+                }
 
-        assertEquals(HttpStatusCode.BadRequest, result.status)
+                val result = client.get("/api/v1/lobby")
+                val parsedLobbies = parseAllLobbies(result)
+
+                assertEquals(HttpStatusCode.OK, result.status)
+                assertEquals(3, parsedLobbies.size)
+
+                assertTrue(
+                    parsedLobbies.contains(
+                        LobbyStatus(
+                            id = 0L,
+                            playersJoined = listOf("playerA"),
+                            gameState = "NOT_STARTED",
+                        )
+                    )
+                )
+
+                assertTrue(
+                    parsedLobbies.contains(
+                        LobbyStatus(
+                            id = 1L,
+                            playersJoined = listOf("playerA"),
+                            gameState = "NOT_STARTED",
+                        )
+                    )
+                )
+
+                assertTrue(
+                    parsedLobbies.contains(
+                        LobbyStatus(
+                            id = 2L,
+                            playersJoined = listOf("playerA"),
+                            gameState = "NOT_STARTED",
+                        )
+                    )
+                )
+            }
     }
 
-    @Test
-    fun `test compile no errors`() = runTest {
-        val result =
-            client.post("/api/v1/redcode/compile/errors") {
-                contentType(ContentType.Application.Json)
-                setBody(Program("MOV 0, 1").json())
-            }
+    @Nested
+    inner class RedcodeCompileErrors {
+        @Test
+        fun `test compile invalid json`() = runTest {
+            val result =
+                client.post("/api/v1/redcode/compile/errors") {
+                    contentType(ContentType.Application.Json)
+                    setBody("{ invalid, : json >:3c")
+                }
 
-        assertEquals(HttpStatusCode.OK, result.status)
-    }
+            assertEquals(HttpStatusCode.BadRequest, result.status)
+        }
 
-    @Test
-    fun `test compile with errors`() = runTest {
-        val result =
-            client.post("/api/v1/redcode/compile/errors") {
-                contentType(ContentType.Application.Json)
-                setBody(Program("ASduhsdlfuhsdf dlfasuihfals Totally valid code :333").json())
-            }
+        @Test
+        fun `test compile no errors`() = runTest {
+            val result =
+                client.post("/api/v1/redcode/compile/errors") {
+                    contentType(ContentType.Application.Json)
+                    setBody(Program("MOV 0, 1").json())
+                }
 
-        assertEquals(HttpStatusCode.OK, result.status)
-        val response = Json.decodeFromString(CompileErrorResponse.serializer(), result.bodyAsText())
-        assertTrue(response.errors.isNotEmpty())
-    }
+            assertEquals(HttpStatusCode.OK, result.status)
+        }
 
-    @Test
-    fun `test if game visualization data is absent before any game round has run`() = runTest {
-        val joinLobbyResponse =
-            client.post("/api/v1/lobby") {
-                contentType(ContentType.Application.Json)
-                setBody(JoinLobbyRequest("playerA").json())
-            }
-        assertEquals(HttpStatusCode.Created, joinLobbyResponse.status)
+        @Test
+        fun `test compile with errors`() = runTest {
+            val result =
+                client.post("/api/v1/redcode/compile/errors") {
+                    contentType(ContentType.Application.Json)
+                    setBody(Program("ASduhsdlfuhsdf dlfasuihfals Totally valid code :333").json())
+                }
 
-        val lobby =
-            Json.decodeFromString(JoinLobbyResponse.serializer(), joinLobbyResponse.bodyAsText())
-        val lobbyId = lobby.lobbyId
-
-        val lobbyStatusResponse = client.get("/api/v1/lobby/$lobbyId/status")
-        assertEquals(HttpStatusCode.OK, lobbyStatusResponse.status)
-
-        val lobbyStatus =
-            Json.decodeFromString(
-                LobbyStatusResponse.serializer(),
-                lobbyStatusResponse.bodyAsText(),
-            )
-        assertEquals(GameState.NOT_STARTED, lobbyStatus.gameState)
-        assertTrue(lobbyStatus.visualizationData.isEmpty())
-    }
-
-    @Test
-    fun `test if game visualization data is present after a game round has run`() = runTest {
-        val joinLobbyResponse =
-            client.post("/api/v1/lobby") {
-                contentType(ContentType.Application.Json)
-                setBody(JoinLobbyRequest("playerA").json())
-            }
-        assertEquals(HttpStatusCode.Created, joinLobbyResponse.status)
-
-        val lobby =
-            Json.decodeFromString(JoinLobbyResponse.serializer(), joinLobbyResponse.bodyAsText())
-        val lobbyId = lobby.lobbyId
-
-        val playerACode =
-            client.post("/api/v1/lobby/$lobbyId/code/playerA") {
-                contentType(ContentType.Application.Json)
-                setBody(Program("MOV 0, 1").json())
-            }
-        assertEquals(HttpStatusCode.OK, playerACode.status)
-
-        val playerBCode =
-            client.post("/api/v1/lobby/$lobbyId/code/playerB") {
-                contentType(ContentType.Application.Json)
-                setBody(Program("MOV 0, 1").json())
-            }
-        assertEquals(HttpStatusCode.OK, playerBCode.status)
-
-        val lobbyStatusResponse = client.get("/api/v1/lobby/$lobbyId/status")
-        assertEquals(HttpStatusCode.OK, lobbyStatusResponse.status)
-
-        val lobbyStatus =
-            Json.decodeFromString(
-                LobbyStatusResponse.serializer(),
-                lobbyStatusResponse.bodyAsText(),
-            )
-        assertEquals(GameState.FINISHED, lobbyStatus.gameState)
-        assertTrue(lobbyStatus.visualizationData.isNotEmpty())
+            assertEquals(HttpStatusCode.OK, result.status)
+            val response =
+                Json.decodeFromString(CompileErrorResponse.serializer(), result.bodyAsText())
+            assertTrue(response.errors.isNotEmpty())
+        }
     }
 }


### PR DESCRIPTION
Closes #308 

Changes POST to `/lobby/{lobbyId}/code/{player}` behaviour to respond with 404 if the lobby doesn't exist yet.

Will probably merge once there's one approval and no other change-requests